### PR TITLE
feat(post): implement uniform image positioning and enhance post card…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ dist/
 .astro/
 
 # dependencies
-node_modules/
+node_modules
 
 # logs
 npm-debug.log*

--- a/config/site.yaml
+++ b/config/site.yaml
@@ -288,6 +288,7 @@ announcements:
 #   enableOGPreview: 启用 Open Graph 预览卡片
 #   previewCacheTime: 预览信息缓存时间（秒）
 #   lazyLoadEmbeds: 延迟加载嵌入内容（提升性能）
+#   postCardImagePosition: 文章卡片封面图位置 (alternating/left/right)
 # -----------------------------------------------------------------------------
 content:
   addBlankTarget: true # 外部链接新窗口打开
@@ -301,6 +302,7 @@ content:
   enableOGPreview: true # OG 预览卡片
   previewCacheTime: 3600 # 预览缓存时间(秒)
   lazyLoadEmbeds: true # 延迟加载嵌入
+  postCardImagePosition: alternating # 文章卡片封面图位置在首页的显示控制 alternating 默认交替显示 left 封面图始终在左侧 right 封面图始终在右侧
 
 # =============================================================================
 # Navigation Routes

--- a/src/components/post/PostItemCard.astro
+++ b/src/components/post/PostItemCard.astro
@@ -19,6 +19,7 @@ export interface PostItemCardProps {
   showTags?: boolean;
   hideCover?: boolean; // 隐藏图片，让内容铺满
   isSimple?: boolean; // 是否简单模式
+  isUniformPosition?: boolean; // 是否统一图片位置（非交替模式）
 }
 
 const {
@@ -28,6 +29,7 @@ const {
   hideCover: hideCoverProp,
   showTags: showTagsProp,
   isSimple = false,
+  isUniformPosition = false,
 } = Astro.props as PostItemCardProps;
 
 const showTags = showTagsProp ?? !isSimple;
@@ -48,11 +50,26 @@ const postDescription = description ?? '';
 
 // 获取 LQIP 样式用于图片占位符
 const lqipProps = getLqipProps(finalCover);
+
+// Stagger padding amounts for uniform position mode (following diagonal edge)
+// Only applied when images are on left, where the diagonal faces the content
+const staggerAmounts = ['pl-0', 'pl-2', 'pl-4', 'pl-6'] as const;
+
+/**
+ * Get stagger padding class for a content row
+ * @param rowIndex - The row index (0-3)
+ * @returns Tailwind padding class or empty string
+ */
+function getStaggerPadding(rowIndex: number): string {
+  // Only apply stagger for left image position (diagonal faces content)
+  if (!isUniformPosition || hideCover || !leftClip) return '';
+  return staggerAmounts[rowIndex];
+}
 ---
 
 <div
   class={cn(
-    'hover:shadow-card-darker group text-card-foreground shadow-card relative flex gap-2 rounded-lg bg-white transition-shadow md:flex-col dark:bg-transparent',
+    'hover:shadow-card-darker group text-card-foreground shadow-card relative flex rounded-lg bg-white transition-shadow md:flex-col dark:bg-transparent',
     'post-item-card',
   )}
 >
@@ -80,13 +97,16 @@ const lqipProps = getLqipProps(finalCover);
   }
   <div
     class={cn(
-      'flex flex-col gap-2 px-4 pb-2 md:pb-4 pt-4 md:pt-1',
+      'flex flex-col gap-2 pb-2 md:pb-4 pt-4 md:pt-1',
+      'px-4 md:px-4',
+      // Reduce margin on the side adjacent to image diagonal when uniform left position
+      isUniformPosition && !hideCover && leftClip && '-ml-3',
       hideCover ? 'w-full' : 'w-[calc(50%+2rem)] md:w-full',
       !hideCover && (leftClip ? 'order-2' : 'order-1'),
       'md:order-0',
     )}
   >
-    <div class={cn('flex w-full justify-between', { 'order-2 justify-start gap-4 pb-3 md:pb-0': isSimple })}>
+    <div class={cn('flex w-full justify-between', { 'order-2 justify-start gap-4 pb-3 md:pb-0': isSimple }, getStaggerPadding(0), 'md:pl-0 md:pr-0')}>
       {
         categoryStr && (
           <a href={categoryLink} class="flex-center hover:text-blue text-muted-foreground text-xs transition duration-300">
@@ -118,7 +138,7 @@ const lqipProps = getLqipProps(finalCover);
         </button>
       </div>
     </div>
-    <div class="mt-1 flex flex-col space-y-1.5 p-0">
+    <div class={cn('mt-1 flex flex-col space-y-1.5 p-0', getStaggerPadding(1), 'md:pl-0 md:pr-0')}>
       <div class="flex items-center gap-2">
         <a href={href} aria-label="post-link" class="min-w-0 flex-1"
           ><h1 class="text-primary hover:text-blue line-clamp-1 truncate text-xl font-bold transition-colors duration-300">
@@ -136,9 +156,12 @@ const lqipProps = getLqipProps(finalCover);
       </div>
     </div>
     <p
-      class={cn('text-muted-foreground line-clamp-3 h-15 text-sm md:h-auto md:max-h-15', {
-        'line-clamp-2 h-10 md:max-h-10': isSimple,
-      })}
+      class={cn(
+        'text-muted-foreground line-clamp-3 h-15 text-sm md:h-auto md:max-h-15',
+        { 'line-clamp-2 h-10 md:max-h-10': isSimple },
+        getStaggerPadding(2),
+        'md:pl-0 md:pr-0',
+      )}
     >
       {postDescription}
     </p>
@@ -150,6 +173,8 @@ const lqipProps = getLqipProps(finalCover);
             hideCover ? 'justify-start' : { 'justify-end': !leftClip },
             leftClip ? 'mr-18' : 'ml-18',
             'md:mx-0 md:justify-start',
+            getStaggerPadding(3),
+            'md:pl-0 md:pr-0',
           )}
         >
           {tags?.length

--- a/src/components/post/PostList.astro
+++ b/src/components/post/PostList.astro
@@ -1,6 +1,6 @@
 ---
 import EmptySvg from '@components/svg/EmptySvg';
-import { defaultCoverList } from '@constants/site-config';
+import { contentConfig, defaultCoverList } from '@constants/site-config';
 import type { Page } from 'astro';
 import { shuffle } from 'es-toolkit';
 import type { BlogPost, PostCardData } from 'types/blog';
@@ -18,6 +18,25 @@ interface Props {
 
 const { posts, page, showPaginator = true, baseUrl, isHomePage = false, isSimple = false } = Astro.props;
 const covers = shuffle(defaultCoverList);
+
+const imagePosition = contentConfig.postCardImagePosition || 'alternating';
+const isUniformPosition = imagePosition !== 'alternating';
+
+/**
+ * Calculate leftClip based on postCardImagePosition config
+ * @param index - The index of the post in the list
+ * @returns true if image should be on the left, false for right
+ */
+function getLeftClip(index: number): boolean {
+  switch (imagePosition) {
+    case 'left':
+      return true;
+    case 'right':
+      return false;
+    default:
+      return index % 2 === 0;
+  }
+}
 ---
 
 {
@@ -37,10 +56,11 @@ const covers = shuffle(defaultCoverList);
             key={post.slug}
             data={post}
             showTags={!isSimple}
-            leftClip={index % 2 === 0}
+            leftClip={getLeftClip(index)}
             randomCover={covers[index % covers.length]}
             hideCover={isSimple}
             isSimple={isSimple}
+            isUniformPosition={isUniformPosition}
           />
         ))}
       </div>

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -232,6 +232,26 @@ type ChristmasConfig = {
 // Map YAML comment config
 export const commentConfig: CommentConfig = yamlConfig.comment || {};
 
+// Content config types
+type ContentConfig = {
+  addBlankTarget?: boolean;
+  smoothScroll?: boolean;
+  addHeadingLevel?: boolean;
+  enhanceCodeBlock?: boolean;
+  enableCodeCopy?: boolean;
+  enableCodeFullscreen?: boolean;
+  enableLinkEmbed?: boolean;
+  enableTweetEmbed?: boolean;
+  enableOGPreview?: boolean;
+  previewCacheTime?: number;
+  lazyLoadEmbeds?: boolean;
+  /** Post card image position: 'alternating' | 'left' | 'right' */
+  postCardImagePosition?: 'alternating' | 'left' | 'right';
+};
+
+// Map YAML content config
+export const contentConfig: ContentConfig = yamlConfig.content || {};
+
 // Map YAML analytics config
 export const analyticsConfig: AnalyticsConfig = yamlConfig.analytics || {};
 


### PR DESCRIPTION
Feat #73

现在可以通过配置 `config/site.yaml` 里的如下字段设置文章卡片封面图位置 (alternating/left/right)

```yaml
content:
  postCardImagePosition: alternating # 文章卡片封面图位置在首页的显示控制 alternating 默认交替显示 left 封面图始终在左侧 right 封面图始终在右侧
```