### PR TITLE
feat(link-preview): add link preview image enhancement with error han…

### DIFF
--- a/src/components/common/CustomContent.astro
+++ b/src/components/common/CustomContent.astro
@@ -28,6 +28,7 @@ const finalConfig = { ...defaultContentConfig, ...config };
   import type { ContentConfig } from '@constants/content-config';
   import { enhanceAllCodeBlocks } from '@lib/code-block-enhancer';
   import { enhanceImages } from '@lib/image-enhancer';
+  import { enhanceLinkPreviews } from '@lib/link-preview-enhancer';
   import { initInfographicEnhancer } from '@lib/infographic-enhancer';
   import { initMermaidEnhancer } from '@lib/mermaid-enhancer';
 
@@ -132,6 +133,9 @@ const finalConfig = { ...defaultContentConfig, ...config };
 
     // Enhance images with loading states
     enhanceImages(contentContainer);
+
+    // Enhance link preview images with error handling
+    enhanceLinkPreviews(contentContainer);
 
     // Mark as enhanced
     contentContainer.setAttribute('data-enhanced', 'true');

--- a/src/lib/link-preview-enhancer.ts
+++ b/src/lib/link-preview-enhancer.ts
@@ -1,0 +1,71 @@
+/**
+ * Link preview image error handling
+ * Handles image load failures by showing graceful fallback UI
+ */
+
+const enhancedImages = new WeakSet<HTMLImageElement>();
+
+/**
+ * Create error placeholder for failed link preview images
+ */
+function createErrorPlaceholder(title: string): HTMLElement {
+  const placeholder = document.createElement('div');
+  placeholder.className = 'link-preview-image-error';
+  placeholder.setAttribute('role', 'img');
+  placeholder.setAttribute('aria-label', `预览图片加载失败: ${title}`);
+
+  // Icon
+  const icon = document.createElement('span');
+  icon.className = 'link-preview-image-error-icon';
+  icon.setAttribute('aria-hidden', 'true');
+
+  // Text
+  const text = document.createElement('span');
+  text.className = 'link-preview-image-error-text';
+  text.textContent = '图片加载失败';
+
+  placeholder.appendChild(icon);
+  placeholder.appendChild(text);
+
+  return placeholder;
+}
+
+/**
+ * Handle image load error
+ */
+function handleImageError(img: HTMLImageElement): void {
+  img.classList.add('error');
+
+  // Get fallback title from data attribute
+  const title = img.getAttribute('data-fallback-title') || '预览';
+
+  // Add error placeholder
+  const imageContainer = img.parentElement;
+
+  if (imageContainer && !imageContainer.querySelector('.link-preview-image-error')) {
+    const placeholder = createErrorPlaceholder(title);
+    imageContainer.appendChild(placeholder);
+  }
+}
+
+/**
+ * Enhance all link preview images in container
+ */
+export function enhanceLinkPreviews(container: Element): void {
+  const images = container.querySelectorAll<HTMLImageElement>('.link-preview-image');
+
+  images.forEach((img) => {
+    // Skip if already enhanced
+    if (enhancedImages.has(img)) return;
+    enhancedImages.add(img);
+
+    // Check if already errored (cached broken image)
+    if (img.complete && img.naturalWidth === 0) {
+      handleImageError(img);
+      return;
+    }
+
+    // Handle future errors
+    img.addEventListener('error', () => handleImageError(img), { once: true });
+  });
+}

--- a/src/lib/markdown/remark-link-embed.ts
+++ b/src/lib/markdown/remark-link-embed.ts
@@ -329,7 +329,7 @@ function generateLinkPreviewHTML(ogData: OGData): string {
           <svg class="h-3 w-3 shrink-0 transition-transform group-hover:translate-x-0.5" aria-hidden="true" viewBox="0 0 12 12"><path fill="currentColor" d="M4 3.5a.5.5 0 0 0-.5.5v4a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5v-.25a.75.75 0 0 1 1.5 0V8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h.25a.75.75 0 0 1 0 1.5zm2.75 0a.75.75 0 0 1 0-1.5h2.5a.75.75 0 0 1 .75.75v2.5a.75.75 0 0 1-1.5 0v-.69L7.28 5.78a.75.75 0 0 1-1.06-1.06L7.44 3.5z"/></svg> 
         </div>
       </div>
-      ${safeImage ? `<div class="bg-muted relative md:w-full shrink-0 aspect-1200/630 h-38"><img src="${safeImage}" alt="${safeTitle}" class="h-full w-full object-cover" loading="lazy" /></div>` : ''}
+      ${safeImage ? `<div class="bg-muted relative md:w-full shrink-0 aspect-1200/630 w-80"><img src="${safeImage}" alt="${safeTitle}" class="link-preview-image h-full md:h-full w-full object-cover" loading="lazy" referrerpolicy="no-referrer" data-fallback-title="${safeTitle}" /></div>` : ''}
     </div>
   </a>
 </div>`;

--- a/src/styles/components/embed.css
+++ b/src/styles/components/embed.css
@@ -40,3 +40,46 @@
 .cp_embed_wrapper {
   @apply my-6;
 }
+
+/* ============================================================================
+   Link Preview Image Error Handling
+   ============================================================================ */
+
+/* Hide broken image when error occurs */
+.link-preview-image.error {
+  display: none;
+}
+
+/* Error placeholder container */
+.link-preview-image-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: 152px; /* Match aspect-1200/630 at h-38 */
+  padding: 2rem;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+/* Broken image icon (SVG mask) */
+.link-preview-image-error-icon {
+  display: block;
+  width: 2.5rem;
+  height: 2.5rem;
+  opacity: 0.5;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23888' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23888' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z'/%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: 100% 100%;
+  mask-size: 100% 100%;
+}
+
+/* Error text */
+.link-preview-image-error-text {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}


### PR DESCRIPTION
为链接预览功能添加图片错误处理机制，当预览图片加载失败时，不再显示浏览器默认的破损图片图标，而是展示统一的错误占位符 UI