### PR TITLE
feat(date): implement unified date handling and formatting

### DIFF
--- a/config/site.yaml
+++ b/config/site.yaml
@@ -22,6 +22,7 @@ site:
   url: https://koharu.cosine.ren # 站点 URL 用于 RSS 和 SEO
   defaultOgImage: /img/avatar.webp # 默认 Open Graph 图片
   startYear: 2024 # 建站年份
+  timezone: Asia/Shanghai # 时区配置 (IANA 格式)，用于日期显示和处理
   keywords: # SEO 关键词
     - 博客
     - Astro

--- a/src/components/announcement/AnnouncementListPopup.tsx
+++ b/src/components/announcement/AnnouncementListPopup.tsx
@@ -7,6 +7,7 @@
 
 import { animation, zIndex } from '@constants/design-tokens';
 import { Icon } from '@iconify/react';
+import { displayDate } from '@lib/date';
 import { cn } from '@lib/utils';
 import { useStore } from '@nanostores/react';
 import {
@@ -17,16 +18,14 @@ import {
   markAsRead,
   readAnnouncementIds,
 } from '@store/announcement';
-import { format } from 'date-fns';
-import { zhCN } from 'date-fns/locale';
 import { AnimatePresence, motion } from 'motion/react';
 import type { Announcement } from '@/types/announcement';
 import { getAnnouncementColor, getAnnouncementIcon } from './AnnouncementToaster';
 
-function formatDate(dateStr?: string): string {
+function formatAnnouncementDate(dateStr?: string): string {
   if (!dateStr) return '';
   try {
-    return format(new Date(dateStr), 'MM/dd', { locale: zhCN });
+    return displayDate.monthDay(dateStr);
   } catch {
     return '';
   }
@@ -45,7 +44,7 @@ function TimelineItem({
 }) {
   const color = getAnnouncementColor(announcement);
   const icon = getAnnouncementIcon(announcement);
-  const dateStr = formatDate(announcement.publishDate ?? announcement.startDate);
+  const dateStr = formatAnnouncementDate(announcement.publishDate ?? announcement.startDate);
 
   const handleClick = () => {
     if (!isRead) {

--- a/src/components/category/CategoryPostList.astro
+++ b/src/components/category/CategoryPostList.astro
@@ -1,9 +1,9 @@
 ---
 import { CONTENT_PADDING } from '@constants/layout';
 import { type Category, getPostsByCategory } from '@lib/content';
+import { displayDate } from '@lib/date';
 import { encodeSlug } from '@lib/route';
 import { cn } from '@lib/utils';
-import { formatInTimeZone } from 'date-fns-tz';
 import SubCategory from './SubCategory.astro';
 
 interface Props {
@@ -47,7 +47,7 @@ const posts = await getPostsByCategory(rootCategory?.name ?? '');
         <div class="category-second-level-container flex flex-col">
           {posts.map((post) => (
             <p class="shoka-decoration-circle group text-primary hover:text-blue relative px-6 py-2 text-base/9">
-              <span class="text-muted-foreground mr-2 text-xs">{formatInTimeZone(post.data.date, 'UTC', 'yy-MM-dd')}</span>
+              <span class="text-muted-foreground mr-2 text-xs">{displayDate.shortDate(post.data.date)}</span>
               <a href={`/post/${encodeSlug(post?.data?.link ?? post.slug)}`} class="dashed-border">
                 {post?.data?.title}
               </a>

--- a/src/components/post/PostItemCard.astro
+++ b/src/components/post/PostItemCard.astro
@@ -5,11 +5,11 @@ import { Button } from '@components/ui/button';
 import { Routes } from '@constants/router';
 import { defaultCoverList } from '@constants/site-config';
 import { buildCategoryPath, buildTagPath, getCategoryArr } from '@lib/content';
+import { displayDate } from '@lib/date';
 import { getLqipProps } from '@lib/lqip';
 import { routeBuilder } from '@lib/route';
 import { cn } from '@lib/utils';
 import { Icon } from 'astro-icon/components';
-import { formatInTimeZone } from 'date-fns-tz';
 import type { PostCardData } from '@/types/blog';
 
 export interface PostItemCardProps {
@@ -120,7 +120,7 @@ function getStaggerPadding(rowIndex: number): string {
           date ? (
             <p class="flex-center gap-1">
               <Icon name="fa6-solid:calendar-days" />
-              {formatInTimeZone(date, 'UTC', 'yyyy-MM-dd')}
+              {displayDate.date(date)}
             </p>
           ) : null
         }

--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -1,8 +1,8 @@
 ---
 import { siteConfig } from '@constants/site-config';
+import { displayDate } from '@lib/date';
 import { getLqipStyle } from '@lib/lqip';
 import { Icon } from 'astro-icon/components';
-import { formatInTimeZone } from 'date-fns-tz';
 import readingTime from 'reading-time';
 import type { BlogPost } from 'types/blog';
 import { MAX_WIDTH } from '@/constants/layout';
@@ -57,12 +57,12 @@ const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
             <p class="mt-3 flex flex-wrap items-center justify-center gap-4 md:text-xs">
               <span class="flex items-center gap-1">
                 <Icon name="fa6-solid:calendar-days" />
-                发表于 {date && formatInTimeZone(date, 'UTC', 'yyyy-MM-dd HH:mm')}
+                发表于 {date && displayDate.datetime(date)}
               </span>
               {updated && (
                 <span class="flex items-center gap-1">
                   <Icon name="fa6-solid:calendar-days" />
-                  更新于 {formatInTimeZone(updated, 'UTC', 'yyyy-MM-dd HH:mm')}
+                  更新于 {displayDate.datetime(updated)}
                 </span>
               )}
               <span class="flex items-center gap-1">

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -1,6 +1,7 @@
 // Import YAML config directly - processed by @rollup/plugin-yaml
 
 import type { CommentConfig, DevConfig, FeaturedCategory, FeaturedSeriesItem, SiteBasicConfig } from '@lib/config/types';
+import { DEFAULT_TIMEZONE, isValidTimezone } from '@lib/timezone';
 import yamlConfig from '../../config/site.yaml';
 import { isReservedSlug, RESERVED_ROUTES } from './router';
 
@@ -281,6 +282,24 @@ export const devConfig: DevConfig = {
   contentRelativePath: yamlConfig.dev?.contentRelativePath ?? 'src/content/blog',
   editors: yamlConfig.dev?.editors ?? [],
 };
+
+// =============================================================================
+// Site Timezone
+// =============================================================================
+
+/**
+ * Site timezone in IANA format
+ * Falls back to 'Asia/Shanghai' if configured timezone is invalid
+ * @default 'Asia/Shanghai'
+ */
+export const siteTimezone: string = (() => {
+  const configuredTz = yamlConfig.site.timezone ?? DEFAULT_TIMEZONE;
+  if (!isValidTimezone(configuredTz)) {
+    console.warn(`[config] Invalid timezone "${configuredTz}", falling back to "${DEFAULT_TIMEZONE}"`);
+    return DEFAULT_TIMEZONE;
+  }
+  return configuredTz;
+})();
 
 // =============================================================================
 // Series Slugs (Pre-computed for navigation filtering)

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,13 +1,36 @@
 import { defineCollection, z } from 'astro:content';
-import type { BlogSchema } from 'types/blog';
+import { parseDateInSiteTimezone, reinterpretUtcAsTimezone } from '@lib/date';
+import type { BlogSchema, BlogSchemaInput } from 'types/blog';
+
+/**
+ * Custom date schema that parses date strings in the site's configured timezone.
+ * This ensures consistent date handling regardless of build environment.
+ *
+ * Accepts:
+ * - Date objects (reinterpreted from UTC to site timezone, since gray-matter
+ *   incorrectly parses "2025-12-29 21:55:00" as UTC)
+ * - Date strings like "2025-12-29 21:55:00" (parsed as site timezone)
+ * - ISO strings like "2025-12-29T21:55:00+08:00" (parsed correctly with offset)
+ */
+const dateInSiteTimezone = z
+  .string()
+  .or(z.date())
+  .transform((val) => {
+    if (val instanceof Date) {
+      // gray-matter has already parsed the date string as UTC, but user intended site timezone.
+      // Reinterpret the UTC values as site timezone to get correct timestamp.
+      return reinterpretUtcAsTimezone(val);
+    }
+    return parseDateInSiteTimezone(val);
+  });
 
 const blogCollection = defineCollection({
   schema: z.object({
     title: z.string(),
     description: z.string().optional(),
     link: z.string().optional(),
-    date: z.date(),
-    updated: z.date().optional(),
+    date: dateInSiteTimezone,
+    updated: dateInSiteTimezone.optional(),
     cover: z.string().optional(),
     tags: z.array(z.string()).optional(),
     // 兼容老 Hexo 博客
@@ -23,7 +46,7 @@ const blogCollection = defineCollection({
     tocNumbering: z.boolean().optional().default(true),
     // 排除 AI 摘要生成
     excludeFromSummary: z.boolean().optional(),
-  }) satisfies z.ZodType<BlogSchema>,
+  }) satisfies z.ZodType<BlogSchema, z.ZodTypeDef, BlogSchemaInput>,
 });
 
 export const collections = {

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -23,6 +23,8 @@ export interface SiteBasicConfig {
   keywords?: string[];
   /** 面包屑导航中首页的显示名称 @default '首页' */
   breadcrumbHome?: string;
+  /** 时区配置 (IANA 格式) @default 'Asia/Shanghai' */
+  timezone?: string;
 }
 
 // =============================================================================

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,127 @@
+/**
+ * Unified Date Formatting Utilities
+ *
+ * Provides consistent date formatting across the site using the configured timezone.
+ * All date display should use these utilities to ensure consistent timezone handling.
+ */
+
+import { siteTimezone } from '@constants/site-config';
+import { formatInTimeZone, fromZonedTime, toDate } from 'date-fns-tz';
+
+/**
+ * Standard date formats used across the site
+ * @internal Used internally by displayDate functions
+ */
+const DateFormats = {
+  /** Full datetime: 2025-01-03 12:30:45 */
+  FULL: 'yyyy-MM-dd HH:mm:ss',
+  /** Datetime without seconds: 2025-01-03 12:30 */
+  DATETIME: 'yyyy-MM-dd HH:mm',
+  /** Date only: 2025-01-03 */
+  DATE: 'yyyy-MM-dd',
+  /** Short date: 25-01-03 */
+  SHORT_DATE: 'yy-MM-dd',
+  /** Month and day: 01/03 */
+  MONTH_DAY: 'MM/dd',
+} as const;
+
+/**
+ * Format a date using the site's configured timezone
+ * @internal Used by displayDate and formatForSeo
+ */
+function formatDate(date: Date | string, formatStr: string = DateFormats.DATE, timezone: string = siteTimezone): string {
+  if (date == null) {
+    throw new Error('Date parameter is required and cannot be null or undefined');
+  }
+
+  const dateObj = typeof date === 'string' ? new Date(date) : date;
+
+  // Validate that the date is valid
+  if (Number.isNaN(dateObj.getTime())) {
+    throw new Error(`Invalid date: ${date}`);
+  }
+
+  return formatInTimeZone(dateObj, timezone, formatStr);
+}
+
+/**
+ * Convenience functions for common date display formats
+ * All functions use the site's configured timezone
+ */
+export const displayDate = {
+  /** Format as yyyy-MM-dd */
+  date: (d: Date | string) => formatDate(d, DateFormats.DATE),
+
+  /** Format as yyyy-MM-dd HH:mm */
+  datetime: (d: Date | string) => formatDate(d, DateFormats.DATETIME),
+
+  /** Format as yy-MM-dd */
+  shortDate: (d: Date | string) => formatDate(d, DateFormats.SHORT_DATE),
+
+  /** Format as MM/dd */
+  monthDay: (d: Date | string) => formatDate(d, DateFormats.MONTH_DAY),
+
+  /** Format as yyyy-MM-dd HH:mm:ss */
+  full: (d: Date | string) => formatDate(d, DateFormats.FULL),
+} as const;
+
+/**
+ * Format date for SEO/Schema.org (ISO date format)
+ *
+ * @param date - Date object or date string
+ * @returns Date in yyyy-MM-dd format for SEO
+ */
+export function formatForSeo(date: Date | string): string {
+  return formatDate(date, DateFormats.DATE);
+}
+
+/**
+ * Parse a date string assuming it's in the site's configured timezone.
+ * Ensures consistent parsing regardless of build environment.
+ *
+ * This solves the issue where `new Date("2025-12-29 21:55:00")` produces
+ * different results depending on the system timezone of the build server.
+ *
+ * @param dateString - Date string to parse (e.g., "2025-12-29 21:55:00")
+ * @returns Date object representing the correct moment in time
+ * @throws {Error} If dateString is empty or results in invalid date
+ */
+export function parseDateInSiteTimezone(dateString: string): Date {
+  if (!dateString || !dateString.trim()) {
+    throw new Error('Date string cannot be empty');
+  }
+
+  // toDate will parse strings without timezone offset as if they were in the specified timezone
+  const result = toDate(dateString, { timeZone: siteTimezone });
+
+  // Validate the parsed date
+  if (Number.isNaN(result.getTime())) {
+    throw new Error(`Failed to parse date string: ${dateString}`);
+  }
+
+  return result;
+}
+
+/**
+ * Reinterpret a Date object that was incorrectly parsed as UTC.
+ *
+ * gray-matter (used by Astro to parse frontmatter) automatically parses YAML dates
+ * like "2025-12-29 21:55:00" as UTC, creating Date(2025-12-29T21:55:00.000Z).
+ * However, the user intended this to be in the site timezone.
+ *
+ * This function extracts the UTC time values and reinterprets them as site timezone,
+ * producing the correct UTC timestamp.
+ *
+ * Example:
+ * - Input: Date(2025-12-29T21:55:00.000Z) ← gray-matter's incorrect UTC parse
+ * - Output: Date(2025-12-29T13:55:00.000Z) ← correct UTC for Asia/Shanghai 21:55
+ *
+ * @param date - Date object incorrectly parsed as UTC by gray-matter
+ * @returns Date object with correct UTC timestamp
+ */
+export function reinterpretUtcAsTimezone(date: Date): Date {
+  // Extract the "wrong" UTC time as a string (e.g., "2025-12-29 21:55:00")
+  const dateStr = formatInTimeZone(date, 'UTC', 'yyyy-MM-dd HH:mm:ss');
+  // Re-parse this string as if it were in the site timezone
+  return fromZonedTime(dateStr, siteTimezone);
+}

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,24 @@
+/**
+ * Timezone Utilities
+ *
+ * Low-level timezone validation and constants.
+ * Separated to avoid circular dependencies between site-config and date modules.
+ */
+
+/** Default timezone used when configuration is invalid or missing */
+export const DEFAULT_TIMEZONE = 'Asia/Shanghai';
+
+/**
+ * Validate if a string is a valid IANA timezone identifier
+ *
+ * @param timezone - Timezone string to validate (e.g., "Asia/Shanghai", "UTC")
+ * @returns true if valid IANA timezone, false otherwise
+ */
+export function isValidTimezone(timezone: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/pages/archives.astro
+++ b/src/pages/archives.astro
@@ -5,8 +5,8 @@ import Cover from '@components/ui/cover/Cover.astro';
 import { CONTENT_PADDING } from '@constants/layout';
 import { siteConfig } from '@constants/site-config';
 import TwoColumnLayout from '@layouts/TwoColumnLayout.astro';
+import { displayDate } from '@lib/date';
 import { encodeSlug } from '@lib/route';
-import { formatInTimeZone } from 'date-fns-tz';
 import Layout from '../layouts/Layout.astro';
 
 const posts = await getCollection('blog', ({ data }) => {
@@ -54,7 +54,7 @@ const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
                 {postsByYear[Number(year)].map((post) => (
                   <p class="shoka-decoration-circle group text-primary hover:text-blue relative px-6 py-2 text-base/9 md:flex md:flex-col md:items-stretch md:text-sm/9">
                     <span class="text-muted-foreground mr-2 text-xs">
-                      {formatInTimeZone(post.data.date, 'UTC', 'yyyy-MM-dd')}
+                      {displayDate.date(post.data.date)}
                     </span>
                     <a
                       href={`/post/${encodeSlug(post.data?.link ?? post.slug)}`}

--- a/src/pages/post/[...slug].astro
+++ b/src/pages/post/[...slug].astro
@@ -9,10 +9,10 @@ import { siteConfig } from '@constants/site-config';
 import Layout from '@layouts/Layout.astro';
 import TwoColumnLayout from '@layouts/TwoColumnLayout.astro';
 import { buildCategoryPath, getCategoryArr, getPostDescription, getPostSummary, getSortedPosts } from '@lib/content';
+import { formatForSeo } from '@lib/date';
 import { encodeSlug } from '@lib/route';
 import { getOgImageUrl } from '@lib/seo/og-image';
 import { Icon } from 'astro-icon/components';
-import { formatInTimeZone } from 'date-fns-tz';
 import { Comment } from '@/components/comment';
 import EditButton from '@/components/EditButton';
 import { extractTextFromMarkdown } from '@/lib/sanitize';
@@ -49,8 +49,8 @@ const jsonLd = {
     name: siteConfig.author ?? siteConfig.name,
     url: Astro.site,
   },
-  datePublished: formatInTimeZone(date, 'UTC', 'yyyy-MM-dd'),
-  ...(post.data.updated && { dateModified: formatInTimeZone(post.data.updated, 'UTC', 'yyyy-MM-dd') }),
+  datePublished: formatForSeo(date),
+  ...(post.data.updated && { dateModified: formatForSeo(post.data.updated) }),
   ...(ogImage && { image: ogImage }),
   mainEntityOfPage: Astro.url.href,
 };

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -6,8 +6,8 @@ import { siteConfig } from '@constants/site-config';
 import Layout from '@layouts/Layout.astro';
 import TwoColumnLayout from '@layouts/TwoColumnLayout.astro';
 import { getPostLastCategory, getSortedPosts, normalizeTag } from '@lib/content';
+import { displayDate } from '@lib/date';
 import { encodeSlug } from '@lib/route';
-import { formatInTimeZone } from 'date-fns-tz';
 
 export async function getStaticPaths() {
   const posts = await getSortedPosts();
@@ -54,7 +54,7 @@ const { tag, posts } = Astro.props;
               return (
                 <p class="shoka-decoration-circle group text-primary relative px-6 py-2 text-base/9 md:overflow-visible">
                   <span class="text-muted-foreground inline-block w-15 text-xs md:relative md:-top-1">
-                    {formatInTimeZone(post.data.date, 'UTC', 'yy-MM-dd')}
+                    {displayDate.shortDate(post.data.date)}
                   </span>
                   <a
                     href={Astro.url.origin + link}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -2,6 +2,7 @@ import type { CollectionEntry } from 'astro:content';
 
 /**
  * Blog post schema - matches the schema defined in content/config.ts
+ * This is the OUTPUT type after Zod transforms are applied.
  */
 export interface BlogSchema {
   title: string;
@@ -19,6 +20,15 @@ export interface BlogSchema {
   tocNumbering?: boolean;
   /** Exclude this post from AI summary generation */
   excludeFromSummary?: boolean;
+}
+
+/**
+ * Blog post schema INPUT type - before Zod transforms.
+ * gray-matter parses YAML dates as Date objects, so date fields accept both.
+ */
+export interface BlogSchemaInput extends Omit<BlogSchema, 'date' | 'updated'> {
+  date: string | Date;
+  updated?: string | Date;
 }
 
 /**


### PR DESCRIPTION
统一时区处理

## Summary
- 支持在 `config/site.yaml` 配置站点时区
- 新增 `src/lib/date.ts` 和 `src/lib/timezone.ts` 统一日期格式化和时区处理
- 修复 gray-matter 将 YAML 日期错误解析为 UTC 的问题
- 修复 CMS 前端 JSON.stringify 导致日期时区偏移的问题