### PR TITLE
feat: migrate Meting API to api.baka.plus and add album support

### DIFF
--- a/src/lib/meting.ts
+++ b/src/lib/meting.ts
@@ -5,7 +5,7 @@
  * Supports NetEase Cloud Music and QQ Music.
  */
 
-const DEFAULT_API = 'https://api.injahow.cn/meting/';
+const DEFAULT_API = 'https://api.baka.plus/meting/';
 const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
 
 export interface MetingSong {
@@ -25,12 +25,11 @@ interface ParsedUrl {
 // URL parsing rules (ported from Shoka player.js:30-47)
 const URL_RULES: [RegExp, string, string][] = [
   [/music\.163\.com.*song.*id=(\d+)/, 'netease', 'song'],
-  [/music\.163\.com.*album.*id=(\d+)/, 'netease', 'album'],
-  [/music\.163\.com.*artist.*id=(\d+)/, 'netease', 'artist'],
+  [/music\.163\.com.*album.*id=(\d+)/, 'netease', 'albumlist'],
   [/music\.163\.com.*playlist.*id=(\d+)/, 'netease', 'playlist'],
   [/music\.163\.com.*discover\/toplist.*id=(\d+)/, 'netease', 'playlist'],
   [/y\.qq\.com.*song\/(\w+)/, 'tencent', 'song'],
-  [/y\.qq\.com.*album\/(\w+)/, 'tencent', 'album'],
+  [/y\.qq\.com.*album\/(\w+)/, 'tencent', 'albumlist'],
   [/y\.qq\.com.*playsquare\/(\w+)/, 'tencent', 'playlist'],
   [/y\.qq\.com.*playlist\/(\w+)/, 'tencent', 'playlist'],
 ];

--- a/src/pages/music.md
+++ b/src/pages/music.md
@@ -20,4 +20,7 @@ description: "我喜欢的音乐"
 - title: 诗岸歌单 山山～全是山山～
   list:
     - https://music.163.com/#/playlist?id=8676645748
+- title: 超かぐや姫！
+  list:
+    - https://music.163.com/#/album?id=358640968
 {% endmedia %}


### PR DESCRIPTION
Summary
- 将 Meting 音乐 API 更换，URL 解析规则中 album 类型改为 albumlist（可支持专辑解析）
- 移除不再支持的 netease artist 类型
- 歌单页面新增「超かぐや姫！」专辑作为 albumlist 功能的实际测试