### PR TITLE
fix(markdown): 允许在加密内容中使用 HTML 标签

### DIFF
--- a/src/lib/markdown/rehype-encrypted-block.ts
+++ b/src/lib/markdown/rehype-encrypted-block.ts
@@ -32,7 +32,7 @@ export function rehypeEncryptedBlock() {
     await Promise.all(
       tasks.map(async ({ node }) => {
         const password = String(node.properties['data-password']);
-        const html = toHtml({ type: 'root', children: node.children });
+        const html = toHtml({ type: 'root', children: node.children }, { allowDangerousHtml: true });
         const { cipher, iv, salt } = await encryptContent(html, password);
 
         // Replace children with empty

--- a/src/lib/markdown/rehype-encrypted-post.ts
+++ b/src/lib/markdown/rehype-encrypted-post.ts
@@ -26,7 +26,7 @@ export function rehypeEncryptedPost() {
     if (!frontmatter?.password) return;
 
     // Serialize the entire tree to HTML
-    const html = toHtml(tree);
+    const html = toHtml(tree, { allowDangerousHtml: true });
     const { cipher, iv, salt } = await encryptContent(html, frontmatter.password);
 
     // Replace the entire tree with a single encrypted container


### PR DESCRIPTION
修改 src/lib/markdown 下 rehype-encrypted-block.ts 和 rehype-encrypted-post.ts 文件

修改其中的 toHtml 函数选项，添加 allowDangerousHtml 选项，以确保加密内容能正确处理包含 HTML 的节点。

```typescript
const html = toHtml(tree, { allowDangerousHtml: true });
```

原来的

<img width="2560" height="1504" alt="屏幕截图 2026-02-18 222749" src="https://github.com/user-attachments/assets/21f562f3-63bb-40d9-8b88-3d9b4c8f0c85" />

<img width="1" height="1" alt="有人吗" src="https://u.ksable.top/p/OmGkCDaUy" />
