### PR TITLE
fix(cli): add YAML quoting for special characters in CLI

### DIFF
--- a/scripts/koharu/utils/new-operations.ts
+++ b/scripts/koharu/utils/new-operations.ts
@@ -158,26 +158,40 @@ export function formatDate(date: Date = new Date()): string {
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }
 
+/** Wrap value in single quotes if it contains YAML-special characters */
+function yamlQuote(value: string): string {
+  if (
+    value === '' ||
+    /[[\]{}:#&*?|>!%@`'",\n]/.test(value) ||
+    /^[\s-]/.test(value) ||
+    /\s$/.test(value) ||
+    /^(true|false|yes|no|null|~|on|off)$/i.test(value)
+  ) {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+  return value;
+}
+
 /**
  * Generate frontmatter YAML string for a post
  */
 export function generatePostFrontmatter(data: PostData): string {
   const lines: string[] = ['---'];
 
-  lines.push(`title: ${data.title}`);
+  lines.push(`title: ${yamlQuote(data.title)}`);
   if (data.link) {
     lines.push(`link: ${data.link}`);
   }
   lines.push(`date: ${formatDate()}`);
 
   if (data.description) {
-    lines.push(`description: ${data.description}`);
+    lines.push(`description: ${yamlQuote(data.description)}`);
   }
 
   if (data.tags.length > 0) {
     lines.push('tags:');
     for (const tag of data.tags) {
-      lines.push(`  - ${tag}`);
+      lines.push(`  - ${yamlQuote(tag)}`);
     }
   }
 
@@ -185,11 +199,11 @@ export function generatePostFrontmatter(data: PostData): string {
   lines.push('categories:');
   if (Array.isArray(data.categories) && data.categories.length > 1) {
     // Nested category: [笔记, 前端]
-    lines.push(`  - [${data.categories.join(', ')}]`);
+    lines.push(`  - [${data.categories.map(yamlQuote).join(', ')}]`);
   } else {
     // Single category
     const cat = Array.isArray(data.categories) ? data.categories[0] : data.categories;
-    lines.push(`  - ${cat}`);
+    lines.push(`  - ${yamlQuote(cat)}`);
   }
 
   if (data.draft) {


### PR DESCRIPTION
Fix #101 

CLI 创建博文时，generatePostFrontmatter() 手动拼接 YAML 字符串，但之前没有对含特殊字符的值进行转义。当标题、描述、标签或分类包含 :、#、[]、引号等。

YAML 保留字符时，生成的 frontmatter 会解析失败。

新增 yamlQuote() 辅助函数，在以下情况自动用单引号包裹值：
  - 空字符串
  - 含 YAML 特殊字符 ([]{}:#&*?|>!%@ 等)
  - 以空白或 - 开头、以空白结尾
  - YAML 布尔/null 保留字 (true, false, yes, no, null, ~, on, off)

  应用于 title、description、tags、categories 字段。