### PR TITLE
fix(syntax_preprocessor): 使用os.EOL替代\n以处理不同系统的换行符

### DIFF
--- a/src/lib/markdown/shoka-preprocessor.ts
+++ b/src/lib/markdown/shoka-preprocessor.ts
@@ -16,6 +16,7 @@
  * is handled by remark plugins since those don't conflict with Markdown.
  */
 import YAML from 'js-yaml';
+import os from 'os';
 import {
   escapeHtml,
   type FriendLinkData,
@@ -42,7 +43,9 @@ function processContainers(text: string, opts: ContainerOptions = {}, _depth = 0
   if (_depth >= MAX_CONTAINER_DEPTH) return text;
   const containers = opts.enableContainers !== false;
   const hexoTags = opts.enableHexoTags !== false;
-  const lines = text.split('\n');
+  // fix: replace \n with os.EOL, different line endings in different systems
+  // if use \n, This will cause parsing errors for syntax such as foldable blocks and tag groups on the Windows system.
+  const lines = text.split(os.EOL);
   const output: string[] = [];
   let i = 0;
 


### PR DESCRIPTION
Windows系统中使用\n会导致可折叠块和标签组等语法解析错误。改用os.EOL确保跨平台兼容性。

#115 

修复前

<img width="2560" height="1504" alt="屏幕截图 2026-02-20 153354" src="https://github.com/user-attachments/assets/c7211faa-a2b1-4726-a154-f6e25fe45109" />

修复后

<img width="2560" height="1504" alt="屏幕截图 2026-02-20 153451" src="https://github.com/user-attachments/assets/a6251bfc-1e57-4b0f-8109-4cd8db971a1b" />

---

为啥你的 dev 分支没了？（佛祖保佑，永无 Bug