### PR TITLE
feat: 添加支持 GPU 等设备的相似性生成脚本

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "astro dev",
     "generate:lqips": "npx tsx src/scripts/generateLqips.ts",
     "generate:similarities": "npx tsx src/scripts/generateSimilarities.ts",
+    "generate:similarities:gpu": "npx tsx src/scripts/generateSimilarities.ts --device gpu",
     "generate:summaries": "npx tsx src/scripts/generateSummaries.ts",
     "generate:summaries:force": "npx tsx src/scripts/generateSummaries.ts --force",
     "generate:all": "npm run generate:lqips && npm run generate:summaries && npm run generate:similarities",


### PR DESCRIPTION
为pnpm generate:similarities 添加transformer.js同构的DeviceType，用于切换生成相似性的设备。
用法：
```bash
pnpm generate:similarities --device <value> 
# value = "auto" | "gpu" | "cpu" | "wasm" | "webgpu" | "cuda" | "dml" | "webnn" | "webnn-npu" | "webnn-gpu" | "webnn-cpu"
```
或快捷使用gpu生成：
```bash
pnpm generate:similarities:gpu
```

经测试相较于默认的cpu，使用gpu生成可以大幅提升速度