### PR TITLE
fix: twikoo race condition bug

### DIFF
--- a/src/components/comment/providers/Twikoo.tsx
+++ b/src/components/comment/providers/Twikoo.tsx
@@ -31,7 +31,10 @@ export default function Twikoo() {
       });
     };
 
-    // astro:page-load fires on initial load AND on subsequent navigations
+    // 直接调用：修复 astro:page-load 在 React 挂载前就已触发的竞态条件
+    initTwikoo();
+
+    // 保留监听器处理后续导航（View Transitions）
     document.addEventListener('astro:page-load', initTwikoo);
     return () => {
       document.removeEventListener('astro:page-load', initTwikoo);


### PR DESCRIPTION
Fix #124 
在 Twikoo.tsx 的 useEffect 中新增直接调用 initTwikoo()，修复 client:only="react" 异步挂载导致 astro:page-load 事件已在监听器注册前触发的竞态条件
