### PR TITLE
feat(配置): 添加默认封面列表配置项

### DIFF
--- a/config/site.yaml
+++ b/config/site.yaml
@@ -293,6 +293,39 @@ announcements:
   #   color: '#6366F1'
   #   publishDate: '2025-12-25'
 
+
+# =============================================================================
+# Default Cover List
+# 默认封面列表 - 文章没有指定封面时将随机从列表中选择一张作为封面，列表不能为空
+# =============================================================================
+# 字段说明：
+#   封面列表 - 封面 url
+# -----------------------------------------------------------------------------
+
+defaultCoverList:
+  - /img/cover/1.webp
+  - /img/cover/2.webp
+  - /img/cover/3.webp
+  - /img/cover/4.webp
+  - /img/cover/5.webp
+  - /img/cover/6.webp
+  - /img/cover/7.webp
+  - /img/cover/8.webp
+  - /img/cover/9.webp
+  - /img/cover/10.webp
+  - /img/cover/11.webp
+  - /img/cover/12.webp
+  - /img/cover/13.webp
+  - /img/cover/14.webp
+  - /img/cover/15.webp
+  - /img/cover/16.webp
+  - /img/cover/17.webp
+  - /img/cover/18.webp
+  - /img/cover/19.webp
+  - /img/cover/20.webp
+  - /img/cover/21.webp
+
+
 # =============================================================================
 # Content Processing Options
 # 内容处理选项 - 控制文章渲染和交互行为

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -205,7 +205,7 @@ export const seoConfig = {
   url: siteConfig.site,
 };
 
-export const defaultCoverList = Array.from({ length: 21 }, (_, index) => index + 1).map((item) => `/img/cover/${item}.webp`);
+export const defaultCoverList = yamlConfig?.defaultCoverList || [];
 
 // Analytics config types
 type AnalyticsConfig = {

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -567,6 +567,7 @@ export interface SiteYamlConfig {
   social?: SocialConfig;
   friends?: FriendsConfig;
   announcements?: AnnouncementConfig[];
+  defaultCoverList?: string[];
   content?: ContentConfig;
   navigation?: RouterItem[];
   comment?: CommentConfig;


### PR DESCRIPTION
在站点配置中增加 `defaultCoverList` 字段，支持通过 YAML 文件自定义默认封面列表。

这样可以更灵活地配置文章未设置封面时，随机显示的封面 URL。

目前主题很多地方采用硬编码实现，希望能将部分选项改为可灵活配置（如随机文章数量、网站壁纸等）。