### PR TITLE
fix(generateLqips): 修复Windows路径分隔符问题

### DIFF
--- a/src/scripts/generateLqips.ts
+++ b/src/scripts/generateLqips.ts
@@ -79,6 +79,8 @@ async function processImage(imagePath: string): Promise<string | null> {
  * Convert file path to short key (relative to /img/)
  */
 function filePathToKey(filePath: string): string {
+  // win32: \ → /, linux not likely a problem
+  filePath = filePath.replace(/\\/g, '/');
   // public/img/cover/1.webp → cover/1.webp
   return filePath.replace(/^public\/img\//, '');
 }


### PR DESCRIPTION
将Windows路径中的反斜杠统一替换为正斜杠，确保在不同操作系统下路径处理一致