### PR TITLE
fix: 修复了修复 vscode://file{path} 格式无法唤起 VS Code 的问题

### DIFF
--- a/config/site.yaml
+++ b/config/site.yaml
@@ -616,12 +616,12 @@ dev:
     - id: vscode
       name: VS Code
       icon: devicon-plain:vscode
-      urlTemplate: 'vscode://file{path}'
+      urlTemplate: 'vscode://file/{path}'
     - id: cursor
       name: Cursor
       icon: simple-icons:cursor
-      urlTemplate: 'cursor://file{path}'
+      urlTemplate: 'cursor://file/{path}'
     - id: zed
       name: Zed
       icon: simple-icons:zedindustries
-      urlTemplate: 'zed://file{path}'
+      urlTemplate: 'zed://file/{path}'


### PR DESCRIPTION
在当前版本中，如果构建或传入的 VS Code URI 缺少 file 后面的斜杠（即格式为 vscode://file{path}），系统无法正确解析并唤起本地的 VS Code。只有在严格遵守 vscode://file/{path} 格式时才能正常工作。

**提交前确认：**
- 我已经在本地测试了这些更改。