### PR TITLE
fix: post cover component not translated

### DIFF
--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -6,6 +6,7 @@ import { getLqipStyle } from '@lib/lqip';
 import { Icon } from 'astro-icon/components';
 import type { BlogPost } from 'types/blog';
 import { MAX_WIDTH } from '@/constants/layout';
+import { getLocaleFromUrl, localizedPath, t } from '@/i18n';
 import WaveSvg from './wave';
 
 export interface CoverProps {
@@ -22,6 +23,8 @@ const isDraft = import.meta.env.DEV && draft === true;
 
 // 获取横幅图片的 LQIP 样式
 const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
+
+const locale = getLocaleFromUrl(Astro.url.pathname);
 ---
 
 <div class="relative flex h-[60dvh] z-0 max-h-200 overflow-hidden">
@@ -35,7 +38,7 @@ const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
           {title}
           <Icon
             name="ri:link"
-            title="复制链接"
+            title={t(locale, "cover.copyLink")}
             class="hover:text-primary cursor-pointer transition-colors duration-300"
             onclick="navigator.clipboard.writeText(window.location.href)"
           />
@@ -57,16 +60,16 @@ const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
             <p class="mt-3 flex flex-wrap items-center justify-center gap-4 md:text-xs">
               <span class="flex items-center gap-1">
                 <Icon name="fa6-solid:calendar-days" />
-                发表于 {date && displayDate.datetime(date)}
+                {t(locale, "post.publishedAt", { date: date && displayDate.datetime(date) })}
               </span>
               {updated && (
                 <span class="flex items-center gap-1">
                   <Icon name="fa6-solid:calendar-days" />
-                  更新于 {displayDate.datetime(updated)}
+                  {t(locale, "post.updatedAt", { date: displayDate.datetime(updated) })}
                 </span>
               )}
               <span class="flex items-center gap-1">
-                <Icon name="fa6-solid:pen-nib" /> {readState?.words} 字
+                <Icon name="fa6-solid:pen-nib" /> {t(locale, "post.wordCount", { count: readState?.words})}
               </span>
               <span class="flex items-center gap-1">
                 <Icon name="fa6-solid:clock" />


### PR DESCRIPTION
This fix addresses the issue that in Cover.astro, some properties, including publishedAt, updatedAt, wordCount were never translated.

Note that it seems readingTime was not managed within Cover.astro. In fact, this property (readState?.text) was properly translated.

**Follow-up:** #160 — fixes an extra `}` syntax error in Cover.astro introduced by this PR, and adds Pagefind search scope optimization.