### PR TITLE
v3.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-koharu",
   "type": "module",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "scripts": {
     "dev": "astro dev",
     "generate:lqips": "npx tsx src/scripts/generateLqips.ts",

--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -69,7 +69,7 @@ const locale = getLocaleFromUrl(Astro.url.pathname);
                 </span>
               )}
               <span class="flex items-center gap-1">
-                <Icon name="fa6-solid:pen-nib" /> {t(locale, "post.wordCount", { count: readState?.words })}}
+                <Icon name="fa6-solid:pen-nib" /> {t(locale, "post.wordCount", { count: readState?.words })}
               </span>
               <span class="flex items-center gap-1">
                 <Icon name="fa6-solid:clock" />

--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -6,6 +6,7 @@ import { getLqipStyle } from '@lib/lqip';
 import { Icon } from 'astro-icon/components';
 import type { BlogPost } from 'types/blog';
 import { MAX_WIDTH } from '@/constants/layout';
+import { getLocaleFromUrl, localizedPath, t } from '@/i18n';
 import WaveSvg from './wave';
 
 export interface CoverProps {
@@ -22,6 +23,8 @@ const isDraft = import.meta.env.DEV && draft === true;
 
 // 获取横幅图片的 LQIP 样式
 const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
+
+const locale = getLocaleFromUrl(Astro.url.pathname);
 ---
 
 <div class="relative flex h-[60dvh] z-0 max-h-200 overflow-hidden">
@@ -35,7 +38,7 @@ const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
           {title}
           <Icon
             name="ri:link"
-            title="复制链接"
+            title={t(locale, "cover.copyLink")}
             class="hover:text-primary cursor-pointer transition-colors duration-300"
             onclick="navigator.clipboard.writeText(window.location.href)"
           />
@@ -57,16 +60,16 @@ const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
             <p class="mt-3 flex flex-wrap items-center justify-center gap-4 md:text-xs">
               <span class="flex items-center gap-1">
                 <Icon name="fa6-solid:calendar-days" />
-                发表于 {date && displayDate.datetime(date)}
+                {t(locale, "post.publishedAt", { date: date && displayDate.datetime(date) })}
               </span>
               {updated && (
                 <span class="flex items-center gap-1">
                   <Icon name="fa6-solid:calendar-days" />
-                  更新于 {displayDate.datetime(updated)}
+                  {t(locale, "post.updatedAt", { date: displayDate.datetime(updated) })}
                 </span>
               )}
               <span class="flex items-center gap-1">
-                <Icon name="fa6-solid:pen-nib" /> {readState?.words} 字
+                <Icon name="fa6-solid:pen-nib" /> {t(locale, "post.wordCount", { count: readState?.words})}
               </span>
               <span class="flex items-center gap-1">
                 <Icon name="fa6-solid:clock" />

--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -6,7 +6,7 @@ import { getLqipStyle } from '@lib/lqip';
 import { Icon } from 'astro-icon/components';
 import type { BlogPost } from 'types/blog';
 import { MAX_WIDTH } from '@/constants/layout';
-import { getLocaleFromUrl, localizedPath, t } from '@/i18n';
+import { getLocaleFromUrl, t } from '@/i18n';
 import WaveSvg from './wave';
 
 export interface CoverProps {
@@ -52,7 +52,7 @@ const locale = getLocaleFromUrl(Astro.url.pathname);
             {isDraft && (
               <span class="inline-flex items-center gap-1.5 rounded-full bg-yellow-500 px-3 py-1.5 text-base font-semibold text-white shadow-lg backdrop-blur-sm text-shadow-none hover:bg-yellow-500 md:px-2.5 md:py-1 md:text-sm">
                 <Icon name="fa6-solid:file-pen" class="h-4 w-4 md:h-3.5 md:w-3.5" />
-                草稿
+                {t(locale, 'post.draft')}
               </span>
             )}
           </h1>
@@ -69,7 +69,7 @@ const locale = getLocaleFromUrl(Astro.url.pathname);
                 </span>
               )}
               <span class="flex items-center gap-1">
-                <Icon name="fa6-solid:pen-nib" /> {t(locale, "post.wordCount", { count: readState?.words})}
+                <Icon name="fa6-solid:pen-nib" /> {t(locale, "post.wordCount", { count: readState?.words })}}
               </span>
               <span class="flex items-center gap-1">
                 <Icon name="fa6-solid:clock" />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -26,7 +26,7 @@ const showComments = frontmatter.comments ?? true;
     <Cover slot="cover" title={frontmatter.coverTitle ?? frontmatter.title} />
     <HomeSider slot="sider" />
     <div class={`shadow-box bg-gradient-start mx-0 flex w-full flex-col gap-8 ${CONTENT_PADDING.standard}`}>
-      <div class="prose md:prose-sm dark:prose-invert">
+      <div class="prose md:prose-sm dark:prose-invert" data-pagefind-body>
         <CustomContent>
           <slot />
         </CustomContent>

--- a/src/pages/post/[...slug].astro
+++ b/src/pages/post/[...slug].astro
@@ -199,7 +199,7 @@ if (post.data.description) {
           <SummaryPanel client:visible summary={summaryText} source={summarySource} className="mt-2" />
         )
       }
-      <article class="prose md:prose-sm dark:prose-invert">
+      <article class="prose md:prose-sm dark:prose-invert" data-pagefind-body>
         <CustomContent Content={Content} />
       </article>
       <Comment />


### PR DESCRIPTION
## Summary
- Add `data-pagefind-body` to post and page layouts, limiting Pagefind to index only article content instead of the entire page (nav, sidebar, footer, comments are now excluded). Closes #159
- Fix extra closing brace `}` in Cover.astro that broke the build (from #158)

## Changes
- `src/pages/post/[...slug].astro` — add `data-pagefind-body` to `<article>`
- `src/layouts/PageLayout.astro` — add `data-pagefind-body` to `.prose` container
- `src/components/ui/cover/Cover.astro` — remove extra `}` in wordCount line

## Impact
Pagefind indexed pages dropped from ~140 to ~33 (only article and static page content), resulting in more precise search results and a smaller search index.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint:fix` passes
- [ ] Search for a keyword that only appears in sidebar/nav — should return no results
- [ ] Search for article content — should return correct results