### PR TITLE
feat(analytics): Umami 访客数据接入

### DIFF
--- a/config/site.yaml
+++ b/config/site.yaml
@@ -552,12 +552,26 @@ comment:
 # id: Umami 网站 ID
 # endpoint: Umami 服务器地址
 # enabled: 是否启用统计
+# statistics_display: 统计信息显示配置
+#   token: Umami 访问令牌
+#   loginType: 登录类型， classic 或 shared
+#   article_page_views: 在文章详情页显示访问量
+#   footer_site_stats: 在页脚 Site Stats 中显示全站访问量
 # -----------------------------------------------------------------------------
 analytics:
   umami:
-    enabled: true
+    enabled: false
     id: your-umami-id
-    endpoint: https://stats.example.com
+    endpoint: https://stats.example.co
+    # 统计信息显示配置
+    statistics_display:
+      token: your-umami-token  # Umami 访问令牌
+      loginType: shared # 登录类型， classic 或 shared
+      # 在文章详情页显示访问量
+      article_page_views: true
+      # 在页脚 Site Stats 中显示全站访问量
+      footer_site_stats: true
+
 
 # =============================================================================
 # SEO Configuration

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,11 +1,14 @@
 ---
 import FooterAnnouncementEntry from '@components/announcement/FooterAnnouncementEntry';
 import { MAX_WIDTH } from '@constants/layout';
-import { icpConfig, siteConfig } from '@constants/site-config';
+import { analyticsConfig, icpConfig, siteConfig } from '@constants/site-config';
 import { getSiteStats } from '@lib/stats';
+import { UmamiConfigToSessionStatsConfig } from '@lib/umami-stats';
 import { cn } from '@lib/utils';
 import { Icon } from 'astro-icon/components';
+import UmamiPVSpan from '@/components/umami/UmamiPVSpan';
 import { getLocaleFromUrl, t } from '@/i18n';
+import type { UmamiConfig } from '@/lib/config/types';
 import SakuraSVG from '../svg/SakuraSvg';
 
 interface Props {
@@ -18,6 +21,8 @@ const locale = getLocaleFromUrl(Astro.url.pathname);
 const stats = await getSiteStats();
 const currentYear = new Date().getFullYear();
 const startYear = siteConfig?.startYear ?? currentYear;
+
+const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig?.umami?.statistics_display?.footer_site_stats;
 ---
 
 <footer class={cn('mt-auto pb-6', className)}>
@@ -47,6 +52,19 @@ const startYear = siteConfig?.startYear ?? currentYear;
         <span class="font-medium">{stats.postCount}</span>
         <span class="text-xs">{t(locale, 'footer.postUnit')}</span>
       </button>
+
+
+      { enableFooterPageviews && (
+
+        <div class="bg-muted-foreground/30 h-4 w-px"></div>
+
+        <div class="flex items-center gap-2 opacity-75 transition-opacity duration-300 hover:opacity-100" title={t(locale, 'footer.pageviews')}>
+          <Icon name="ri:eye-line" class="h-4 w-4" />
+          <span class="font-medium"><UmamiPVSpan client:load sessionStatsConfig={UmamiConfigToSessionStatsConfig(analyticsConfig.umami as UmamiConfig)}/></span>
+          <span class="text-xs">{t(locale, 'footer.pageviews')}</span>
+        </div>
+      )}
+
     </div>
 
     <!-- Copyright -->

--- a/src/components/post/PostItemCard.astro
+++ b/src/components/post/PostItemCard.astro
@@ -3,15 +3,19 @@
 import { Badge } from '@components/ui/badge';
 import { Button } from '@components/ui/button';
 import { Routes } from '@constants/router';
-import { defaultCoverList } from '@constants/site-config';
+import { analyticsConfig, defaultCoverList } from '@constants/site-config';
 import { buildCategoryPath, buildTagPath, getCategoryArr, translateCategoryName } from '@lib/content';
 import { displayDate } from '@lib/date';
 import { getLqipProps } from '@lib/lqip';
 import { routeBuilder } from '@lib/route';
+import { UmamiConfigToSessionStatsConfig } from '@lib/umami-stats';
 import { cn } from '@lib/utils';
 import { Icon } from 'astro-icon/components';
+import UmamiPVSpan from '@/components/umami/UmamiPVSpan';
 import { defaultLocale, getLocaleFromUrl, getLocaleLabel, localizedPath, t } from '@/i18n';
+import type { UmamiConfig } from '@/lib/config/types';
 import type { PostCardData } from '@/types/blog';
+import type { UmamiSessionStatsConfig } from '@/types/umami-stats';
 
 export interface PostItemCardProps {
   data: PostCardData;
@@ -68,6 +72,11 @@ function getStaggerPadding(rowIndex: number): string {
   if (!isUniformPosition || hideCover || !leftClip) return '';
   return staggerAmounts[rowIndex];
 }
+
+const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig?.umami?.statistics_display?.article_page_views;
+const sessionStatsConfig = enableFooterPageviews
+  ? UmamiConfigToSessionStatsConfig(analyticsConfig.umami as UmamiConfig, href)
+  : null;
 ---
 
 <div
@@ -139,6 +148,18 @@ function getStaggerPadding(rowIndex: number): string {
           <Icon name="fa6-solid:clock" />
           {readingTime}
         </button>
+
+        <!-- Pageviews -->
+        {
+          enableFooterPageviews && (
+            <p class="flex-center gap-1">
+              <Icon name="ri:eye-line" class="h-4 w-4" />
+              <UmamiPVSpan client:load sessionStatsConfig={sessionStatsConfig as UmamiSessionStatsConfig} />
+              {t(locale, 'footer.pageviews')}
+            </p>
+          )
+        }
+
       </div>
     </div>
     <div class={cn('mt-1 flex flex-col space-y-1.5 p-0', getStaggerPadding(1), 'md:pl-0 md:pr-0')}>

--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -1,12 +1,18 @@
 ---
-import { siteConfig } from '@constants/site-config';
+import { analyticsConfig, siteConfig } from '@constants/site-config';
 import { getPostReadingTime } from '@lib/content/posts';
 import { displayDate } from '@lib/date';
 import { getLqipStyle } from '@lib/lqip';
+import { UmamiConfigToSessionStatsConfig } from '@lib/umami-stats';
 import { Icon } from 'astro-icon/components';
 import type { BlogPost } from 'types/blog';
+import UmamiPVSpan from '@/components/umami/UmamiPVSpan';
 import { MAX_WIDTH } from '@/constants/layout';
-import { getLocaleFromUrl, t } from '@/i18n';
+import { getLocaleFromUrl, localizedPath, t } from '@/i18n';
+import type { UmamiConfig } from '@/lib/config/types';
+import { getPostSlug } from '@/lib/content/locale';
+import { encodeSlug } from '@/lib/route';
+import type { UmamiSessionStatsConfig } from '@/types/umami-stats';
 import WaveSvg from './wave';
 
 export interface CoverProps {
@@ -25,6 +31,13 @@ const isDraft = import.meta.env.DEV && draft === true;
 const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
 
 const locale = getLocaleFromUrl(Astro.url.pathname);
+
+const href = data && localizedPath(`/post/${encodeSlug(getPostSlug(data))}`, locale);
+
+const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig?.umami?.statistics_display?.article_page_views;
+const sessionStatsConfig = enableFooterPageviews
+  ? UmamiConfigToSessionStatsConfig(analyticsConfig.umami as UmamiConfig, href)
+  : null;
 ---
 
 <div class="relative flex h-[60dvh] z-0 max-h-200 overflow-hidden">
@@ -75,6 +88,13 @@ const locale = getLocaleFromUrl(Astro.url.pathname);
                 <Icon name="fa6-solid:clock" />
                 {readState?.text}
               </span>
+              { enableFooterPageviews && (
+                <span class="flex items-center gap-1">
+                  <Icon name="ri:eye-line" class="h-4 w-4" />
+                  <UmamiPVSpan client:load sessionStatsConfig={sessionStatsConfig as UmamiSessionStatsConfig} />
+                  {t(locale, 'footer.pageviews')}
+                </span>
+              )}
             </p>
           )}
         </>

--- a/src/components/umami/UmamiPVSpan.tsx
+++ b/src/components/umami/UmamiPVSpan.tsx
@@ -1,0 +1,32 @@
+import { safeGetPageviews } from '@lib/umami-stats';
+import { useEffect, useRef } from 'react';
+import type { UmamiSessionStatsConfig } from '@/types/umami-stats';
+
+interface Props {
+  sessionStatsConfig: UmamiSessionStatsConfig;
+  path?: string;
+}
+
+export default function UmamiPVSpan({ sessionStatsConfig }: Props) {
+  const containerRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const fetchPageviews = async () => {
+      try {
+        const sitePageviews = await safeGetPageviews(sessionStatsConfig);
+
+        if (containerRef.current) {
+          containerRef.current.textContent = sitePageviews.toString();
+        }
+      } catch (error) {
+        console.error('Error fetching Umami Pageviews:', error);
+      }
+    };
+
+    fetchPageviews();
+  }, [sessionStatsConfig]); // 确保包含所有依赖
+
+  return <span ref={containerRef}>...</span>;
+}

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -224,6 +224,12 @@ type AnalyticsConfig = {
     enabled: boolean;
     id: string;
     endpoint: string;
+    statistics_display?: {
+      token: string;
+      loginType: 'classic' | 'shared';
+      article_page_views: boolean;
+      footer_site_stats: boolean;
+    };
   };
 };
 

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -175,6 +175,7 @@ export const uiStrings: UIStrings = {
   'footer.runningDays': 'Running for {days} days',
   'footer.wordUnit': 'words',
   'footer.postUnit': 'posts',
+  'footer.pageviews': 'Page views',
 
   // ── Pagination ──────────────────────────────────────────────
   'pagination.prev': 'Previous',

--- a/src/i18n/translations/ja.ts
+++ b/src/i18n/translations/ja.ts
@@ -174,6 +174,7 @@ export const uiStrings: UIStrings = {
   'footer.runningDays': '稼働して{days}日が経過',
   'footer.wordUnit': '文字',
   'footer.postUnit': '投稿',
+  'footer.pageviews': 'アクセス数',
 
   // ── ページ付け ──────────────────────────────────────────────
   'pagination.prev': '前へ',

--- a/src/i18n/translations/zh.ts
+++ b/src/i18n/translations/zh.ts
@@ -174,6 +174,7 @@ export const uiStrings = {
   'footer.runningDays': '已运行 {days} 天',
   'footer.wordUnit': '字',
   'footer.postUnit': '篇',
+  'footer.pageviews': '访问量',
 
   // ── Pagination ──────────────────────────────────────────────
   'pagination.prev': '上一页',

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -439,6 +439,12 @@ export interface UmamiConfig {
   enabled: boolean;
   id: string;
   endpoint: string;
+  statistics_display?: {
+    token: string;
+    loginType: 'classic' | 'shared';
+    article_page_views: boolean;
+    footer_site_stats: boolean;
+  };
 }
 
 export interface AnalyticsConfig {

--- a/src/lib/umami-stats.ts
+++ b/src/lib/umami-stats.ts
@@ -1,0 +1,65 @@
+/**
+ * 获取 Umami Session Stats
+ * @param UmamiSessionStatsConfig
+ * @returns
+ */
+
+import type { UmamiConfig } from '@lib/config/types';
+import type { UmamiSessionStats, UmamiSessionStatsConfig } from '@/types/umami-stats';
+
+const getSessionStats = async (config: UmamiSessionStatsConfig): Promise<UmamiSessionStats> => {
+  const { baseUrl, websiteId, token, loginType = 'classic', path } = config;
+
+  const url = new URL(baseUrl);
+  url.pathname = `/api/websites/${websiteId}/stats`;
+
+  const headers = new Headers();
+  headers.append('accept', 'application/json');
+  if (loginType === 'classic') {
+    headers.append('Authorization', `Bearer ${token}`);
+  } else if (loginType === 'shared') {
+    headers.append('x-umami-share-token', token);
+  } else {
+    throw new Error('loginType must be classic or shared');
+  }
+
+  const params = new URLSearchParams();
+  params.append('startAt', config.startAt?.toString() || '0');
+  params.append('endAt', config.endAt?.toString() || Date.now().toString());
+  path && params.append('path', encodeURI(path));
+  url.search = params.toString();
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers,
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(`Error: ${data.data?.error}`);
+  }
+  return data;
+};
+
+const safeGetPageviews = async (config: UmamiSessionStatsConfig): Promise<number | 'N/A'> => {
+  try {
+    const stats = await getSessionStats(config);
+    if (typeof stats.pageviews === 'number') {
+      return stats.pageviews;
+    } else {
+      return stats.pageviews.value;
+    }
+  } catch (error) {
+    console.error('Error fetching Umami Pageviews:', error);
+    return 'N/A';
+  }
+};
+
+const UmamiConfigToSessionStatsConfig = (config: UmamiConfig, path?: string): UmamiSessionStatsConfig => ({
+  baseUrl: config.endpoint || '',
+  websiteId: config.id || '',
+  token: config.statistics_display?.token || '',
+  loginType: config.statistics_display?.loginType || 'classic',
+  path,
+});
+
+export { getSessionStats, safeGetPageviews, UmamiConfigToSessionStatsConfig };

--- a/src/types/umami-stats.ts
+++ b/src/types/umami-stats.ts
@@ -1,0 +1,83 @@
+// Umami Session Stats type
+
+// Umami 的不同版本 api 返回的数据结构是不同的
+// 但一般都含有以下字段：
+// pageviews: 页面访问量
+// visitors: 访问者数量
+
+export interface UmamiSessionStats {
+  pageviews:
+    | {
+        value: number;
+      }
+    | number;
+  visitors:
+    | {
+        value: number;
+      }
+    | number;
+  visits?:
+    | {
+        value: number;
+      }
+    | number;
+  countries?:
+    | {
+        value: number;
+      }
+    | number;
+  events?:
+    | {
+        value: number;
+      }
+    | number;
+  bounces?:
+    | {
+        value: number;
+      }
+    | number;
+  totaltime?:
+    | {
+        value: number;
+      }
+    | number;
+  comparison?: {
+    pageviews?:
+      | {
+          value: number;
+        }
+      | number;
+    visitors?:
+      | {
+          value: number;
+        }
+      | number;
+    visits?:
+      | {
+          value: number;
+        }
+      | number;
+    bounces?:
+      | {
+          value: number;
+        }
+      | number;
+    totaltime?:
+      | {
+          value: number;
+        }
+      | number;
+  };
+}
+
+export interface UmamiSessionStatsConfig {
+  baseUrl: string;
+  websiteId: string;
+  token: string;
+  // login 方式
+  loginType?: 'classic' | 'shared';
+  path?: string;
+  // 时间范围
+  startAt?: number;
+  endAt?: number;
+}


### PR DESCRIPTION
#31 [Roadmap] 中的 Umami 访客数据接入

- 在页脚添加全站访问量统计显示
- 支持文章详情页访问量显示
- 新增 Umami 统计相关类型定义和工具函数
- 更新多语言翻译支持统计显示

<img width="1446" height="339" alt="image" src="https://github.com/user-attachments/assets/fab26671-417c-41bb-b5f0-7b70b54d2a68" />
<img width="1053" height="99" alt="image" src="https://github.com/user-attachments/assets/abd7ee41-b22a-427e-8ef2-a4ddb412f4b1" />
