### PR TITLE
fix: make Meting API endpoint configurable

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -237,6 +237,22 @@ src/content/blog/
 
 更多详细配置（内容翻译、添加新语言等）请参考 [README 的多语言配置章节](./README.md#多语言配置i18n)。
 
+### 背景音乐（BGM）
+
+在 `config/site.yaml` 中配置背景音乐播放器：
+
+```yaml
+bgm:
+  enabled: true
+  # metingApi: https://163.hyc.moe/  # 自定义 Meting API 地址（默认 https://163.hyc.moe/）
+  audio:
+    - title: 我的歌单
+      list:
+        - https://music.163.com/playlist?id=你的歌单ID
+```
+
+音频播放器通过 [Meting](https://github.com/metowolf/meting) API 解析音乐平台链接，默认使用公共 API，**推荐自部署以获得更稳定的服务**。
+
 ### 内容生成（可选）
 
 使用 Koharu CLI 生成内容资产：

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ pnpm koharu generate all          # 生成全部
 - **评论系统**（Waline / Giscus / Remark42 / Twikoo，推荐使用 Waline）
 - 数据统计（Umami）
 - **国际化配置（i18n）**
+- **背景音乐（BGM）**：配置 `bgm.audio` 添加歌单，`bgm.metingApi` 可自定义 [Meting](https://github.com/metowolf/meting) API 地址（默认 `https://163.hyc.moe/`，推荐自部署）
 - **追番页面（Bangumi）**：配置 `bangumi.userId` 即可开启，注释掉整段关闭
 - 圣诞特辑开关
 - 开发工具配置（`config/site.yaml` 的 `dev` 部分，用于本地编辑器跳转）
@@ -324,7 +325,7 @@ comment:
 - 公告系统
   ![公告系统](https://r2.cosine.ren/i/2026/01/a4660955f52438b3cc2d21bdc931bbd4.gif)
 - Shoka 兼容 Markdown 语法 - 提醒块、折叠块、标签卡、文字特效、隐藏文字、注音标注、练习题等
-- 音视频播放器 - 支持网易云音乐歌单和视频播放
+- 音视频播放器 - 支持音乐歌单和视频播放，通过 [Meting](https://github.com/metowolf/meting) API 解析，推荐自部署
 
 ## 使用本主题的博客
 

--- a/config/site.yaml
+++ b/config/site.yaml
@@ -584,6 +584,7 @@ seo:
 # =============================================================================
 bgm:
   enabled: true  # (有 audio 时自动启用，显式 false 可禁用)
+  # metingApi: https://163.hyc.moe/  # Meting API 地址，默认为 https://163.hyc.moe/，推荐自部署
   audio:
     - title: 最爱山山
       list:

--- a/src/components/bgm/GlobalBGMPlayer.tsx
+++ b/src/components/bgm/GlobalBGMPlayer.tsx
@@ -27,9 +27,10 @@ import { $bgmPanelOpen, closeBgmPanel } from '@/store/bgm';
 
 interface GlobalBGMPlayerProps {
   audioGroups: BgmAudioGroup[];
+  metingApi?: string;
 }
 
-export default function GlobalBGMPlayer({ audioGroups }: GlobalBGMPlayerProps) {
+export default function GlobalBGMPlayer({ audioGroups, metingApi }: GlobalBGMPlayerProps) {
   const { t } = useTranslation();
   const panelOpen = useStore($bgmPanelOpen);
   const isDrawerOpen = useStore($isDrawerOpen);
@@ -57,7 +58,7 @@ export default function GlobalBGMPlayer({ audioGroups }: GlobalBGMPlayerProps) {
 
     async function resolve() {
       try {
-        const results = await Promise.all(audioGroups.map((group) => resolvePlaylist(group.list)));
+        const results = await Promise.all(audioGroups.map((group) => resolvePlaylist(group.list, metingApi)));
 
         if (!cancelled) {
           const allTracks: MetingSong[] = [];
@@ -83,7 +84,7 @@ export default function GlobalBGMPlayer({ audioGroups }: GlobalBGMPlayerProps) {
     return () => {
       cancelled = true;
     };
-  }, [panelOpen, audioGroups, retryKey]);
+  }, [panelOpen, audioGroups, retryKey, metingApi]);
 
   // Audio hook at top level — Audio element persists across panel open/close
   const player = useAudioPlayer(tracks);

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -296,8 +296,9 @@ export const christmasConfig: ChristmasConfig = yamlConfig.christmas || {
 };
 
 // Map YAML bgm config
-export const bgmConfig: { enabled: boolean; audio: BgmAudioGroup[] } = {
+export const bgmConfig: { enabled: boolean; metingApi?: string; audio: BgmAudioGroup[] } = {
   enabled: yamlConfig.bgm?.enabled ?? (yamlConfig.bgm?.audio?.length ?? 0) > 0,
+  metingApi: yamlConfig.bgm?.metingApi,
   audio: yamlConfig.bgm?.audio ?? [],
 };
 

--- a/src/content/blog/tools/astro-koharu-guide.md
+++ b/src/content/blog/tools/astro-koharu-guide.md
@@ -1634,7 +1634,9 @@ fn main() {
 
 *音频播放器（`enableShokaHexoTags`）：*
 
-使用 `{% media audio %}` 标签嵌入音频播放器，支持网易云音乐等平台（通过 Meting API 解析）：
+使用 `{% media audio %}` 标签嵌入音频播放器，支持网易云音乐、QQ 音乐等平台（通过 [Meting](https://github.com/metowolf/meting) API 解析）。
+
+默认使用 `https://163.hyc.moe/` 作为 Meting API，可在 `config/site.yaml` 的 `bgm.metingApi` 中自定义，推荐自部署以获得更稳定的服务。
 
 ```markdown
 {% media audio %}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -347,7 +347,7 @@ const canonicalHref = canonicalOverride ?? Astro.url.href;
       </main>
       {bgmConfig.enabled && bgmConfig.audio.length > 0 && (
         <div transition:persist="global-bgm">
-          <GlobalBGMPlayer client:only="react" audioGroups={bgmConfig.audio} />
+          <GlobalBGMPlayer client:only="react" audioGroups={bgmConfig.audio} metingApi={bgmConfig.metingApi} />
         </div>
       )}
       <FloatingGroup client:only="react" />

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -534,6 +534,8 @@ export interface BgmAudioGroup {
 
 export interface BgmConfig {
   enabled?: boolean;
+  /** Meting API endpoint URL. Defaults to 'https://163.hyc.moe/' */
+  metingApi?: string;
   audio?: BgmAudioGroup[];
 }
 

--- a/src/lib/meting.ts
+++ b/src/lib/meting.ts
@@ -90,9 +90,10 @@ export async function fetchMeting(server: string, type: string, id: string, apiU
   const cached = getFromCache(cacheKey);
   if (cached) return cached;
 
-  const api = apiUrl || DEFAULT_API;
+  const url = new URL(apiUrl || DEFAULT_API);
   const params = new URLSearchParams({ server, type, id });
-  const response = await fetch(`${api}?${params}`);
+  url.search = params.toString();
+  const response = await fetch(url);
   if (!response.ok) throw new Error(`Meting API error: ${response.status}`);
 
   const data: unknown = await response.json();

--- a/src/lib/meting.ts
+++ b/src/lib/meting.ts
@@ -5,7 +5,7 @@
  * Supports NetEase Cloud Music and QQ Music.
  */
 
-const DEFAULT_API = 'https://api.baka.plus/meting/';
+const DEFAULT_API = 'https://163.hyc.moe/';
 const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
 
 export interface MetingSong {


### PR DESCRIPTION
## Summary
- Change default Meting API from `api.baka.plus` to `163.hyc.moe` for better reliability
- Add `metingApi` config option in `config/site.yaml` to allow users to self-host their Meting API
- Pass configurable API endpoint through the component chain (`BgmConfig` → `Layout` → `GlobalBGMPlayer` → `resolvePlaylist`)

## Changed Files
- `config/site.yaml` — add `metingApi` config field
- `src/lib/config/types.ts` — add `metingApi` to `BgmConfig` interface
- `src/lib/meting.ts` — update default API URL
- `src/constants/site-config.ts` — map `metingApi` from YAML config
- `src/layouts/Layout.astro` — pass `metingApi` prop to player
- `src/components/bgm/GlobalBGMPlayer.tsx` — accept and forward `metingApi` prop
- `README.md` — remove "网易云" specific wording

## Test plan
- [ ] Verify BGM player loads playlists with default API
- [ ] Verify custom `metingApi` in site.yaml is respected
- [ ] Verify build passes (`pnpm build`)