### PR TITLE
refactor: simplify Docker build and improve deployment scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,9 @@
 node_modules/
 dist/
 .astro/
-.cache/
+# Keep .cache/og-data.json for build acceleration (OG metadata cache)
+.cache/transformers/
+.cache/summaries-cache/
 .git/
 .gitignore
 .husky/

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,6 @@ docker/rebuild.sh
 docker/nginx/*.md
 
 # Local configuration and secrets
-.env
 .env*
 *.local
 

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 # ANALYZE=true
+BLOG_PORT=4321
+
+# REACT_GRAB=true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,14 +29,10 @@ ARG REMARK_SITE_ID
 ARG UMAMI_ID
 ARG UMAMI_ENDPOINT
 
-# Set environment variables for build
-ENV REMARK_URL=${REMARK_URL}
-ENV REMARK_SITE_ID=${REMARK_SITE_ID}
-ENV UMAMI_ID=${UMAMI_ID}
-ENV UMAMI_ENDPOINT=${UMAMI_ENDPOINT}
-
-# Build the static site
-RUN pnpm build
+# Build the static site (pass ARGs as inline env to avoid persisting in layer history)
+RUN REMARK_URL=$REMARK_URL REMARK_SITE_ID=$REMARK_SITE_ID \
+    UMAMI_ID=$UMAMI_ID UMAMI_ENDPOINT=$UMAMI_ENDPOINT \
+    pnpm build
 
 # =============================================================================
 # Stage 2: Production (nginx)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,16 +23,8 @@ RUN pnpm install --frozen-lockfile --prod=false
 # Copy source files
 COPY . .
 
-# Build-time arguments for sensitive configuration
-ARG REMARK_URL
-ARG REMARK_SITE_ID
-ARG UMAMI_ID
-ARG UMAMI_ENDPOINT
-
-# Build the static site (pass ARGs as inline env to avoid persisting in layer history)
-RUN REMARK_URL=$REMARK_URL REMARK_SITE_ID=$REMARK_SITE_ID \
-    UMAMI_ID=$UMAMI_ID UMAMI_ENDPOINT=$UMAMI_ENDPOINT \
-    pnpm build
+# Build the static site
+RUN pnpm build
 
 # =============================================================================
 # Stage 2: Production (nginx)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,11 +17,6 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-      args:
-        - REMARK_URL=${REMARK_URL}
-        - REMARK_SITE_ID=${REMARK_SITE_ID}
-        - UMAMI_ID=${UMAMI_ID}
-        - UMAMI_ENDPOINT=${UMAMI_ENDPOINT}
     ports:
       - "${BLOG_PORT:-4321}:80"
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost/"]
       interval: 30s
       timeout: 3s
+      start_period: 5s
       retries: 3
     networks:
       - astro-koharu-network

--- a/docker/rebuild.sh
+++ b/docker/rebuild.sh
@@ -20,9 +20,10 @@ echo "  或单独运行生成脚本以更新 LQIP、相似度和 AI 摘要数据
 echo "================================================"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
 
-ENV_FILE="${ENV_FILE:-../.env}"
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
 SKIP_DOWN="${SKIP_DOWN:-false}"
 
 if [ ! -f "$ENV_FILE" ]; then
@@ -31,7 +32,7 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
-COMPOSE_CMD=(docker compose --env-file "$ENV_FILE")
+COMPOSE_CMD=(docker compose --env-file "$ENV_FILE" -f "$SCRIPT_DIR/docker-compose.yml")
 
 echo "🔐 Using environment file: $ENV_FILE"
 echo "🔄 Rebuilding blog with updated configuration..."
@@ -44,5 +45,6 @@ fi
 echo "🚀 Building and starting containers..."
 "${COMPOSE_CMD[@]}" up -d --build
 
+BLOG_PORT=$(grep -E '^BLOG_PORT=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"' || true)
 echo "✅ Blog rebuilt and deployed!"
-echo "🌐 Access at: http://localhost:4321"
+echo "🌐 Access at: http://localhost:${BLOG_PORT:-4321}"

--- a/docker/rebuild.sh
+++ b/docker/rebuild.sh
@@ -14,9 +14,9 @@ set -euo pipefail
 
 # Reminder for content generation
 echo "================================================"
-echo "  Reminder: 如果添加了新内容，建议先运行："
-echo "    pnpm generate:all"
-echo "  或单独运行生成脚本以更新 LQIP、相似度和 AI 摘要数据"
+echo "  Reminder: If you added new content, consider running first:"
+echo "    pnpm koharu generate all"
+echo "  to update LQIP, similarity vectors, and AI summaries."
 echo "================================================"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -28,7 +28,7 @@ SKIP_DOWN="${SKIP_DOWN:-false}"
 
 if [ ! -f "$ENV_FILE" ]; then
   echo "❌ Environment file not found at $ENV_FILE"
-  echo "   Copy .env.example to .env in the repository root and fill in your secrets."
+  echo "   Copy .env.example to .env in the repository root and fill in your values."
   exit 1
 fi
 

--- a/docs/overview/11-deployment-adapters.md
+++ b/docs/overview/11-deployment-adapters.md
@@ -57,17 +57,9 @@ cp .env.example .env
 ```bash
 # 博客端口（默认 4321）
 BLOG_PORT=4321
-
-# Remark42 评论系统（可选）
-REMARK_URL=https://remark.example.com
-REMARK_SITE_ID=your-site-id
-
-# Umami 统计分析（可选）
-UMAMI_ID=your-umami-id
-UMAMI_ENDPOINT=https://umami.example.com
 ```
 
-> 评论和统计的环境变量是 **构建时** 注入到静态 HTML 中的，修改后需要重新构建镜像。
+> 评论系统和统计分析等配置已迁移到 `config/site.yaml`，无需通过环境变量注入。
 
 **2. 构建并启动**
 
@@ -142,10 +134,6 @@ ports:
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
 | `BLOG_PORT` | 主机端口映射 | `4321` |
-| `REMARK_URL` | Remark42 服务地址 | — |
-| `REMARK_SITE_ID` | Remark42 站点 ID | — |
-| `UMAMI_ID` | Umami 追踪 ID | — |
-| `UMAMI_ENDPOINT` | Umami 服务地址 | — |
 
 ## 本地测试
 

--- a/docs/overview/11-deployment-adapters.md
+++ b/docs/overview/11-deployment-adapters.md
@@ -35,11 +35,117 @@ pnpm build
 node dist/server/entry.mjs
 ```
 
-或使用 Docker（见 `/docker` 目录）：
+### Docker 部署
+
+项目提供了完整的 Docker 部署方案：多阶段构建（`node:22-alpine` 构建静态文件 → `nginx:alpine` 托管服务），最终镜像仅包含 nginx + 静态资源。
+
+#### 前置要求
+
+- Docker Engine 20.10+
+- Docker Compose V2 (`docker compose` 命令)
+
+#### 快速开始
+
+**1. 配置环境变量**
 
 ```bash
-./docker/rebuild.sh
+cp .env.example .env
 ```
+
+编辑 `.env` 填入你的配置：
+
+```bash
+# 博客端口（默认 4321）
+BLOG_PORT=4321
+
+# Remark42 评论系统（可选）
+REMARK_URL=https://remark.example.com
+REMARK_SITE_ID=your-site-id
+
+# Umami 统计分析（可选）
+UMAMI_ID=your-umami-id
+UMAMI_ENDPOINT=https://umami.example.com
+```
+
+> 评论和统计的环境变量是 **构建时** 注入到静态 HTML 中的，修改后需要重新构建镜像。
+
+**2. 构建并启动**
+
+```bash
+# 使用 pnpm 快捷命令
+pnpm docker:up
+
+# 或手动执行完整命令
+docker compose --env-file ./.env -f docker/docker-compose.yml up -d --build
+```
+
+访问 `http://localhost:4321`（或你配置的 `BLOG_PORT`）。
+
+**3. 日常管理**
+
+```bash
+pnpm docker:logs      # 查看实时日志
+pnpm docker:down      # 停止并移除容器
+pnpm docker:rebuild   # 完整重建（停旧容器 → 重新构建 → 启动）
+```
+
+#### 更新内容后重新部署
+
+当修改了博客内容、`config/site.yaml` 或 `.env` 后：
+
+```bash
+# 建议先生成内容资产（LQIP、相似度、AI 摘要）
+pnpm koharu generate all
+
+# 然后重新构建部署
+pnpm docker:rebuild
+```
+
+`rebuild.sh` 会自动检查 `.env` 是否存在，并提示是否需要运行内容生成脚本。
+
+#### 目录结构
+
+```plain
+docker/
+├── Dockerfile            # 多阶段构建（builder → nginx）
+├── docker-compose.yml    # 服务编排
+├── nginx/
+│   └── default.conf      # nginx 配置（gzip、缓存、安全头、SPA 路由）
+└── rebuild.sh            # 一键重建脚本
+```
+
+#### nginx 配置说明
+
+`docker/nginx/default.conf` 包含以下优化：
+
+- **Gzip 压缩**：JS/CSS/SVG/JSON 等资源自动压缩
+- **静态资源长缓存**：`js/css/图片/字体` 设置 1 年缓存 + `immutable`
+- **HTML 短缓存**：1 小时 + `must-revalidate`
+- **安全头**：`X-Frame-Options`、`X-Content-Type-Options`、`Referrer-Policy`
+- **Astro 路由**：`try_files $uri $uri/index.html =404` 匹配静态输出格式
+- **Pagefind 搜索**：独立缓存策略（1 天）
+
+#### 自定义反向代理
+
+如果在 nginx/Caddy 等反向代理后面运行，将端口映射改为仅绑定 127.0.0.1：
+
+```yaml
+# docker-compose.yml
+ports:
+  - "127.0.0.1:${BLOG_PORT:-4321}:80"
+```
+
+然后在外层反向代理中配置转发到该端口。
+
+#### 环境变量
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `BLOG_PORT` | 主机端口映射 | `4321` |
+| `REMARK_URL` | Remark42 服务地址 | — |
+| `REMARK_SITE_ID` | Remark42 站点 ID | — |
+| `UMAMI_ID` | Umami 追踪 ID | — |
+| `UMAMI_ENDPOINT` | Umami 服务地址 | — |
 
 ## 本地测试
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "knip": "knip",
     "koharu": "npx tsx scripts/koharu.tsx",
     "cms": "cd cms && pnpm dev",
-    "cms:install": "cd cms && pnpm install"
+    "cms:install": "cd cms && pnpm install",
+    "docker:up": "docker compose --env-file ./.env -f docker/docker-compose.yml up -d --build",
+    "docker:down": "docker compose -f docker/docker-compose.yml down",
+    "docker:logs": "docker compose -f docker/docker-compose.yml logs -f",
+    "docker:rebuild": "bash docker/rebuild.sh"
   },
   "dependencies": {
     "@antv/infographic": "^0.2.4",

--- a/src/hooks/useActiveHeading.ts
+++ b/src/hooks/useActiveHeading.ts
@@ -89,7 +89,6 @@ function createActiveHeadingStore(offsetTop: number) {
           if (!id) continue;
 
           if (entry.isIntersecting) {
-            // Track this heading as visible with its boundingClientRect.top
             // Using entry.boundingClientRect avoids forced reflow
             visibleHeadings.set(id, entry.boundingClientRect.top);
           } else {


### PR DESCRIPTION
## Summary
- Remove REMARK/UMAMI build-time ARGs from Dockerfile and docker-compose.yml (config migrated to `site.yaml`)
- Add `docker:up/down/logs/rebuild` npm scripts; improve `rebuild.sh` (English messages, dynamic port, repo-root-aware paths)
- Expand Docker deployment docs with nginx details, directory structure, and daily management commands

## Changed Files
- `.dockerignore` — refine cache ignoring, remove redundant `.env` entry
- `.env.example` — add `BLOG_PORT` and `REACT_GRAB` entries
- `docker/Dockerfile` — remove 4 build ARGs and ENV declarations
- `docker/docker-compose.yml` — remove build args, add healthcheck `start_period`
- `docker/rebuild.sh` — English messages, repo-root `cd`, dynamic port output
- `docs/overview/11-deployment-adapters.md` — comprehensive Docker deployment guide
- `package.json` — add `docker:*` convenience scripts
- `src/hooks/useActiveHeading.ts` — remove redundant comment