### PR TITLE
feat(analytics): add Umami pageview stats display

### DIFF
--- a/config/site.yaml
+++ b/config/site.yaml
@@ -552,12 +552,26 @@ comment:
 # id: Umami 网站 ID
 # endpoint: Umami 服务器地址
 # enabled: 是否启用统计
+# statistics_display: 统计信息显示配置
+#   token: Umami 访问令牌
+#   loginType: 登录类型， classic 或 shared
+#   article_page_views: 在文章详情页显示访问量
+#   footer_site_stats: 在页脚 Site Stats 中显示全站访问量
 # -----------------------------------------------------------------------------
 analytics:
   umami:
-    enabled: true
+    enabled: false
     id: your-umami-id
-    endpoint: https://stats.example.com
+    endpoint: https://stats.example.co
+    # 统计信息显示配置
+    statistics_display:
+      token: your-umami-token  # Umami 访问令牌
+      loginType: shared # 登录类型， classic 或 shared
+      # 在文章详情页显示访问量
+      article_page_views: true
+      # 在页脚 Site Stats 中显示全站访问量
+      footer_site_stats: true
+
 
 # =============================================================================
 # SEO Configuration

--- a/config/site.yaml
+++ b/config/site.yaml
@@ -559,7 +559,7 @@ comment:
 # -----------------------------------------------------------------------------
 analytics:
   umami:
-    enabled: false
+    enabled: true
     id: your-umami-id
     endpoint: https://stats.example.com
     statistics_display:

--- a/config/site.yaml
+++ b/config/site.yaml
@@ -562,10 +562,10 @@ analytics:
     enabled: true
     id: your-umami-id
     endpoint: https://stats.example.com
-    statistics_display:
-      token: your-umami-share-token
-      article_page_views: true
-      footer_site_stats: true
+    # statistics_display:
+    #   token: your-umami-share-token
+    #   article_page_views: true
+    #   footer_site_stats: true
 
 # =============================================================================
 # SEO Configuration

--- a/config/site.yaml
+++ b/config/site.yaml
@@ -553,8 +553,7 @@ comment:
 # endpoint: Umami 服务器地址
 # enabled: 是否启用统计
 # statistics_display: 统计信息显示配置
-#   token: Umami 访问令牌
-#   loginType: 登录类型， classic 或 shared
+#   token: Umami 分享链接令牌（只读，可安全暴露到客户端）
 #   article_page_views: 在文章详情页显示访问量
 #   footer_site_stats: 在页脚 Site Stats 中显示全站访问量
 # -----------------------------------------------------------------------------
@@ -562,16 +561,11 @@ analytics:
   umami:
     enabled: false
     id: your-umami-id
-    endpoint: https://stats.example.co
-    # 统计信息显示配置
+    endpoint: https://stats.example.com
     statistics_display:
-      token: your-umami-token  # Umami 访问令牌
-      loginType: shared # 登录类型， classic 或 shared
-      # 在文章详情页显示访问量
+      token: your-umami-share-token
       article_page_views: true
-      # 在页脚 Site Stats 中显示全站访问量
       footer_site_stats: true
-
 
 # =============================================================================
 # SEO Configuration

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,11 +1,14 @@
 ---
 import FooterAnnouncementEntry from '@components/announcement/FooterAnnouncementEntry';
 import { MAX_WIDTH } from '@constants/layout';
-import { icpConfig, siteConfig } from '@constants/site-config';
+import { analyticsConfig, icpConfig, siteConfig } from '@constants/site-config';
 import { getSiteStats } from '@lib/stats';
+import { UmamiConfigToSessionStatsConfig } from '@lib/umami-stats';
 import { cn } from '@lib/utils';
 import { Icon } from 'astro-icon/components';
+import UmamiPVSpan from '@/components/umami/UmamiPVSpan';
 import { getLocaleFromUrl, t } from '@/i18n';
+import type { UmamiConfig } from '@/lib/config/types';
 import SakuraSVG from '../svg/SakuraSvg';
 
 interface Props {
@@ -18,6 +21,8 @@ const locale = getLocaleFromUrl(Astro.url.pathname);
 const stats = await getSiteStats();
 const currentYear = new Date().getFullYear();
 const startYear = siteConfig?.startYear ?? currentYear;
+
+const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig?.umami?.statistics_display?.footer_site_stats;
 ---
 
 <footer class={cn('mt-auto pb-6', className)}>
@@ -47,6 +52,19 @@ const startYear = siteConfig?.startYear ?? currentYear;
         <span class="font-medium">{stats.postCount}</span>
         <span class="text-xs">{t(locale, 'footer.postUnit')}</span>
       </button>
+
+
+      { enableFooterPageviews && (
+
+        <div class="bg-muted-foreground/30 h-4 w-px"></div>
+
+        <div class="flex items-center gap-2 opacity-75 transition-opacity duration-300 hover:opacity-100" title={t(locale, 'footer.pageviews')}>
+          <Icon name="ri:eye-line" class="h-4 w-4" />
+          <span class="font-medium"><UmamiPVSpan client:load sessionStatsConfig={UmamiConfigToSessionStatsConfig(analyticsConfig.umami as UmamiConfig)}/></span>
+          <span class="text-xs">{t(locale, 'footer.pageviews')}</span>
+        </div>
+      )}
+
     </div>
 
     <!-- Copyright -->

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,14 +1,12 @@
 ---
 import FooterAnnouncementEntry from '@components/announcement/FooterAnnouncementEntry';
 import { MAX_WIDTH } from '@constants/layout';
-import { analyticsConfig, icpConfig, siteConfig } from '@constants/site-config';
+import { icpConfig, siteConfig, umamiSiteStatsConfig } from '@constants/site-config';
 import { getSiteStats } from '@lib/stats';
-import { UmamiConfigToSessionStatsConfig } from '@lib/umami-stats';
 import { cn } from '@lib/utils';
 import { Icon } from 'astro-icon/components';
 import UmamiPVSpan from '@/components/umami/UmamiPVSpan';
 import { getLocaleFromUrl, t } from '@/i18n';
-import type { UmamiConfig } from '@/lib/config/types';
 import SakuraSVG from '../svg/SakuraSvg';
 
 interface Props {
@@ -21,8 +19,6 @@ const locale = getLocaleFromUrl(Astro.url.pathname);
 const stats = await getSiteStats();
 const currentYear = new Date().getFullYear();
 const startYear = siteConfig?.startYear ?? currentYear;
-
-const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig?.umami?.statistics_display?.footer_site_stats;
 ---
 
 <footer class={cn('mt-auto pb-6', className)}>
@@ -53,16 +49,15 @@ const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig
         <span class="text-xs">{t(locale, 'footer.postUnit')}</span>
       </button>
 
-
-      { enableFooterPageviews && (
-
-        <div class="bg-muted-foreground/30 h-4 w-px"></div>
-
-        <div class="flex items-center gap-2 opacity-75 transition-opacity duration-300 hover:opacity-100" title={t(locale, 'footer.pageviews')}>
-          <Icon name="ri:eye-line" class="h-4 w-4" />
-          <span class="font-medium"><UmamiPVSpan client:load sessionStatsConfig={UmamiConfigToSessionStatsConfig(analyticsConfig.umami as UmamiConfig)}/></span>
-          <span class="text-xs">{t(locale, 'footer.pageviews')}</span>
-        </div>
+      {umamiSiteStatsConfig && (
+        <>
+          <div class="bg-muted-foreground/30 h-4 w-px"></div>
+          <div class="flex items-center gap-2 opacity-75 transition-opacity duration-300 hover:opacity-100" title={t(locale, 'stats.pageviews')}>
+            <Icon name="ri:eye-line" class="h-4 w-4" />
+            <span class="font-medium"><UmamiPVSpan client:load statsConfig={umamiSiteStatsConfig} /></span>
+            <span class="text-xs">{t(locale, 'stats.pageviews')}</span>
+          </div>
+        </>
       )}
 
     </div>

--- a/src/components/post/PostItemCard.astro
+++ b/src/components/post/PostItemCard.astro
@@ -3,15 +3,19 @@
 import { Badge } from '@components/ui/badge';
 import { Button } from '@components/ui/button';
 import { Routes } from '@constants/router';
-import { defaultCoverList } from '@constants/site-config';
+import { analyticsConfig, defaultCoverList } from '@constants/site-config';
 import { buildCategoryPath, buildTagPath, getCategoryArr, translateCategoryName } from '@lib/content';
 import { displayDate } from '@lib/date';
 import { getLqipProps } from '@lib/lqip';
 import { routeBuilder } from '@lib/route';
+import { UmamiConfigToSessionStatsConfig } from '@lib/umami-stats';
 import { cn } from '@lib/utils';
 import { Icon } from 'astro-icon/components';
+import UmamiPVSpan from '@/components/umami/UmamiPVSpan';
 import { defaultLocale, getLocaleFromUrl, getLocaleLabel, localizedPath, t } from '@/i18n';
+import type { UmamiConfig } from '@/lib/config/types';
 import type { PostCardData } from '@/types/blog';
+import type { UmamiSessionStatsConfig } from '@/types/umami-stats';
 
 export interface PostItemCardProps {
   data: PostCardData;
@@ -68,6 +72,11 @@ function getStaggerPadding(rowIndex: number): string {
   if (!isUniformPosition || hideCover || !leftClip) return '';
   return staggerAmounts[rowIndex];
 }
+
+const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig?.umami?.statistics_display?.article_page_views;
+const sessionStatsConfig = enableFooterPageviews
+  ? UmamiConfigToSessionStatsConfig(analyticsConfig.umami as UmamiConfig, href)
+  : null;
 ---
 
 <div
@@ -139,6 +148,18 @@ function getStaggerPadding(rowIndex: number): string {
           <Icon name="fa6-solid:clock" />
           {readingTime}
         </button>
+
+        <!-- Pageviews -->
+        {
+          enableFooterPageviews && (
+            <p class="flex-center gap-1">
+              <Icon name="ri:eye-line" class="h-4 w-4" />
+              <UmamiPVSpan client:load sessionStatsConfig={sessionStatsConfig as UmamiSessionStatsConfig} />
+              {t(locale, 'footer.pageviews')}
+            </p>
+          )
+        }
+
       </div>
     </div>
     <div class={cn('mt-1 flex flex-col space-y-1.5 p-0', getStaggerPadding(1), 'md:pl-0 md:pr-0')}>

--- a/src/components/post/PostItemCard.astro
+++ b/src/components/post/PostItemCard.astro
@@ -3,19 +3,16 @@
 import { Badge } from '@components/ui/badge';
 import { Button } from '@components/ui/button';
 import { Routes } from '@constants/router';
-import { analyticsConfig, defaultCoverList } from '@constants/site-config';
+import { createArticleStatsConfig, defaultCoverList } from '@constants/site-config';
 import { buildCategoryPath, buildTagPath, getCategoryArr, translateCategoryName } from '@lib/content';
 import { displayDate } from '@lib/date';
 import { getLqipProps } from '@lib/lqip';
 import { routeBuilder } from '@lib/route';
-import { UmamiConfigToSessionStatsConfig } from '@lib/umami-stats';
 import { cn } from '@lib/utils';
 import { Icon } from 'astro-icon/components';
 import UmamiPVSpan from '@/components/umami/UmamiPVSpan';
 import { defaultLocale, getLocaleFromUrl, getLocaleLabel, localizedPath, t } from '@/i18n';
-import type { UmamiConfig } from '@/lib/config/types';
 import type { PostCardData } from '@/types/blog';
-import type { UmamiSessionStatsConfig } from '@/types/umami-stats';
 
 export interface PostItemCardProps {
   data: PostCardData;
@@ -73,10 +70,7 @@ function getStaggerPadding(rowIndex: number): string {
   return staggerAmounts[rowIndex];
 }
 
-const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig?.umami?.statistics_display?.article_page_views;
-const sessionStatsConfig = enableFooterPageviews
-  ? UmamiConfigToSessionStatsConfig(analyticsConfig.umami as UmamiConfig, href)
-  : null;
+const pageStatsConfig = createArticleStatsConfig(href);
 ---
 
 <div
@@ -149,16 +143,13 @@ const sessionStatsConfig = enableFooterPageviews
           {readingTime}
         </button>
 
-        <!-- Pageviews -->
-        {
-          enableFooterPageviews && (
-            <p class="flex-center gap-1">
-              <Icon name="ri:eye-line" class="h-4 w-4" />
-              <UmamiPVSpan client:load sessionStatsConfig={sessionStatsConfig as UmamiSessionStatsConfig} />
-              {t(locale, 'footer.pageviews')}
-            </p>
-          )
-        }
+        {pageStatsConfig && (
+          <p class="flex-center gap-1">
+            <Icon name="ri:eye-line" class="h-4 w-4" />
+            <UmamiPVSpan client:visible statsConfig={pageStatsConfig} />
+            {t(locale, 'stats.pageviews')}
+          </p>
+        )}
 
       </div>
     </div>

--- a/src/components/post/PostItemCard.astro
+++ b/src/components/post/PostItemCard.astro
@@ -144,11 +144,11 @@ const pageStatsConfig = createArticleStatsConfig(href);
         </button>
 
         {pageStatsConfig && (
-          <p class="flex-center gap-1">
+          <span class="flex-center gap-1">
             <Icon name="ri:eye-line" class="h-4 w-4" />
             <UmamiPVSpan client:visible statsConfig={pageStatsConfig} />
             {t(locale, 'stats.pageviews')}
-          </p>
+          </span>
         )}
 
       </div>

--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -1,12 +1,18 @@
 ---
-import { siteConfig } from '@constants/site-config';
+import { analyticsConfig, siteConfig } from '@constants/site-config';
 import { getPostReadingTime } from '@lib/content/posts';
 import { displayDate } from '@lib/date';
 import { getLqipStyle } from '@lib/lqip';
+import { UmamiConfigToSessionStatsConfig } from '@lib/umami-stats';
 import { Icon } from 'astro-icon/components';
 import type { BlogPost } from 'types/blog';
+import UmamiPVSpan from '@/components/umami/UmamiPVSpan';
 import { MAX_WIDTH } from '@/constants/layout';
-import { getLocaleFromUrl, t } from '@/i18n';
+import { getLocaleFromUrl, localizedPath, t } from '@/i18n';
+import type { UmamiConfig } from '@/lib/config/types';
+import { getPostSlug } from '@/lib/content/locale';
+import { encodeSlug } from '@/lib/route';
+import type { UmamiSessionStatsConfig } from '@/types/umami-stats';
 import WaveSvg from './wave';
 
 export interface CoverProps {
@@ -25,6 +31,13 @@ const isDraft = import.meta.env.DEV && draft === true;
 const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
 
 const locale = getLocaleFromUrl(Astro.url.pathname);
+
+const href = data && localizedPath(`/post/${encodeSlug(getPostSlug(data))}`, locale);
+
+const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig?.umami?.statistics_display?.article_page_views;
+const sessionStatsConfig = enableFooterPageviews
+  ? UmamiConfigToSessionStatsConfig(analyticsConfig.umami as UmamiConfig, href)
+  : null;
 ---
 
 <div class="relative flex h-[60dvh] z-0 max-h-200 overflow-hidden">
@@ -75,6 +88,13 @@ const locale = getLocaleFromUrl(Astro.url.pathname);
                 <Icon name="fa6-solid:clock" />
                 {readState?.text}
               </span>
+              { enableFooterPageviews && (
+                <span class="flex items-center gap-1">
+                  <Icon name="ri:eye-line" class="h-4 w-4" />
+                  <UmamiPVSpan client:load sessionStatsConfig={sessionStatsConfig as UmamiSessionStatsConfig} />
+                  {t(locale, 'footer.pageviews')}
+                </span>
+              )}
             </p>
           )}
         </>

--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -1,18 +1,15 @@
 ---
-import { analyticsConfig, siteConfig } from '@constants/site-config';
+import { Routes } from '@constants/router';
+import { createArticleStatsConfig, siteConfig } from '@constants/site-config';
 import { getPostReadingTime } from '@lib/content/posts';
 import { displayDate } from '@lib/date';
 import { getLqipStyle } from '@lib/lqip';
-import { UmamiConfigToSessionStatsConfig } from '@lib/umami-stats';
+import { routeBuilder } from '@lib/route';
 import { Icon } from 'astro-icon/components';
 import type { BlogPost } from 'types/blog';
 import UmamiPVSpan from '@/components/umami/UmamiPVSpan';
 import { MAX_WIDTH } from '@/constants/layout';
 import { getLocaleFromUrl, localizedPath, t } from '@/i18n';
-import type { UmamiConfig } from '@/lib/config/types';
-import { getPostSlug } from '@/lib/content/locale';
-import { encodeSlug } from '@/lib/route';
-import type { UmamiSessionStatsConfig } from '@/types/umami-stats';
 import WaveSvg from './wave';
 
 export interface CoverProps {
@@ -32,12 +29,9 @@ const bannerLqipStyle = getLqipStyle('/img/site_header_1920.webp');
 
 const locale = getLocaleFromUrl(Astro.url.pathname);
 
-const href = data && localizedPath(`/post/${encodeSlug(getPostSlug(data))}`, locale);
+const href = data && localizedPath(routeBuilder(Routes.Post, data), locale);
 
-const enableFooterPageviews = analyticsConfig?.umami?.enabled && analyticsConfig?.umami?.statistics_display?.article_page_views;
-const sessionStatsConfig = enableFooterPageviews
-  ? UmamiConfigToSessionStatsConfig(analyticsConfig.umami as UmamiConfig, href)
-  : null;
+const pageStatsConfig = href ? createArticleStatsConfig(href) : null;
 ---
 
 <div class="relative flex h-[60dvh] z-0 max-h-200 overflow-hidden">
@@ -88,11 +82,11 @@ const sessionStatsConfig = enableFooterPageviews
                 <Icon name="fa6-solid:clock" />
                 {readState?.text}
               </span>
-              { enableFooterPageviews && (
+              {pageStatsConfig && (
                 <span class="flex items-center gap-1">
                   <Icon name="ri:eye-line" class="h-4 w-4" />
-                  <UmamiPVSpan client:load sessionStatsConfig={sessionStatsConfig as UmamiSessionStatsConfig} />
-                  {t(locale, 'footer.pageviews')}
+                  <UmamiPVSpan client:load statsConfig={pageStatsConfig} />
+                  {t(locale, 'stats.pageviews')}
                 </span>
               )}
             </p>

--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -85,7 +85,7 @@ const pageStatsConfig = href ? createArticleStatsConfig(href) : null;
               {pageStatsConfig && (
                 <span class="flex items-center gap-1">
                   <Icon name="ri:eye-line" class="h-4 w-4" />
-                  <UmamiPVSpan client:load statsConfig={pageStatsConfig} />
+                  <UmamiPVSpan client:idle statsConfig={pageStatsConfig} />
                   {t(locale, 'stats.pageviews')}
                 </span>
               )}

--- a/src/components/umami/UmamiPVSpan.tsx
+++ b/src/components/umami/UmamiPVSpan.tsx
@@ -8,16 +8,17 @@ interface Props {
 
 export default function UmamiPVSpan({ statsConfig }: Props) {
   const [pageviews, setPageviews] = useState<number | null | undefined>(undefined);
+  const { baseUrl, websiteId, shareToken, path } = statsConfig;
 
   useEffect(() => {
     let cancelled = false;
-    getPageviews(statsConfig).then((pv) => {
+    getPageviews({ baseUrl, websiteId, shareToken, path }).then((pv) => {
       if (!cancelled) setPageviews(pv);
     });
     return () => {
       cancelled = true;
     };
-  }, [statsConfig]);
+  }, [baseUrl, websiteId, shareToken, path]);
 
   if (pageviews === undefined) return <span>...</span>;
   if (pageviews === null) return <span>N/A</span>;

--- a/src/components/umami/UmamiPVSpan.tsx
+++ b/src/components/umami/UmamiPVSpan.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 export default function UmamiPVSpan({ statsConfig }: Props) {
-  const [pageviews, setPageviews] = useState<number | 'N/A' | null>(null);
+  const [pageviews, setPageviews] = useState<number | null | undefined>(undefined);
 
   useEffect(() => {
     let cancelled = false;
@@ -19,6 +19,7 @@ export default function UmamiPVSpan({ statsConfig }: Props) {
     };
   }, [statsConfig]);
 
-  if (pageviews === null) return <span>...</span>;
+  if (pageviews === undefined) return <span>...</span>;
+  if (pageviews === null) return <span>N/A</span>;
   return <span>{pageviews}</span>;
 }

--- a/src/components/umami/UmamiPVSpan.tsx
+++ b/src/components/umami/UmamiPVSpan.tsx
@@ -1,0 +1,32 @@
+import { safeGetPageviews } from '@lib/umami-stats';
+import { useEffect, useRef } from 'react';
+import type { UmamiSessionStatsConfig } from '@/types/umami-stats';
+
+interface Props {
+  sessionStatsConfig: UmamiSessionStatsConfig;
+  path?: string;
+}
+
+export default function UmamiPVSpan({ sessionStatsConfig }: Props) {
+  const containerRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const fetchPageviews = async () => {
+      try {
+        const sitePageviews = await safeGetPageviews(sessionStatsConfig);
+
+        if (containerRef.current) {
+          containerRef.current.textContent = sitePageviews.toString();
+        }
+      } catch (error) {
+        console.error('Error fetching Umami Pageviews:', error);
+      }
+    };
+
+    fetchPageviews();
+  }, [sessionStatsConfig]); // 确保包含所有依赖
+
+  return <span ref={containerRef}>...</span>;
+}

--- a/src/components/umami/UmamiPVSpan.tsx
+++ b/src/components/umami/UmamiPVSpan.tsx
@@ -12,9 +12,13 @@ export default function UmamiPVSpan({ statsConfig }: Props) {
 
   useEffect(() => {
     let cancelled = false;
-    getPageviews({ baseUrl, websiteId, shareToken, path }).then((pv) => {
-      if (!cancelled) setPageviews(pv);
-    });
+    getPageviews({ baseUrl, websiteId, shareToken, path })
+      .then((pv) => {
+        if (!cancelled) setPageviews(pv);
+      })
+      .catch(() => {
+        if (!cancelled) setPageviews(null);
+      });
     return () => {
       cancelled = true;
     };

--- a/src/components/umami/UmamiPVSpan.tsx
+++ b/src/components/umami/UmamiPVSpan.tsx
@@ -1,32 +1,24 @@
-import { safeGetPageviews } from '@lib/umami-stats';
-import { useEffect, useRef } from 'react';
-import type { UmamiSessionStatsConfig } from '@/types/umami-stats';
+import { getPageviews } from '@lib/umami-stats';
+import { useEffect, useState } from 'react';
+import type { UmamiStatsConfig } from '@/types/umami-stats';
 
 interface Props {
-  sessionStatsConfig: UmamiSessionStatsConfig;
-  path?: string;
+  statsConfig: UmamiStatsConfig;
 }
 
-export default function UmamiPVSpan({ sessionStatsConfig }: Props) {
-  const containerRef = useRef<HTMLSpanElement>(null);
+export default function UmamiPVSpan({ statsConfig }: Props) {
+  const [pageviews, setPageviews] = useState<number | 'N/A' | null>(null);
 
   useEffect(() => {
-    if (!containerRef.current) return;
-
-    const fetchPageviews = async () => {
-      try {
-        const sitePageviews = await safeGetPageviews(sessionStatsConfig);
-
-        if (containerRef.current) {
-          containerRef.current.textContent = sitePageviews.toString();
-        }
-      } catch (error) {
-        console.error('Error fetching Umami Pageviews:', error);
-      }
+    let cancelled = false;
+    getPageviews(statsConfig).then((pv) => {
+      if (!cancelled) setPageviews(pv);
+    });
+    return () => {
+      cancelled = true;
     };
+  }, [statsConfig]);
 
-    fetchPageviews();
-  }, [sessionStatsConfig]); // 确保包含所有依赖
-
-  return <span ref={containerRef}>...</span>;
+  if (pageviews === null) return <span>...</span>;
+  return <span>{pageviews}</span>;
 }

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -272,13 +272,17 @@ export const analyticsConfig: AnalyticsConfig = yamlConfig.analytics || {};
 
 const _umami = analyticsConfig?.umami;
 
-/** Pre-computed site-wide pageview stats config. null when disabled. */
+/** Pre-computed site-wide pageview stats config. null when disabled or token missing. */
 export const umamiSiteStatsConfig: UmamiStatsConfig | null =
-  _umami?.enabled && _umami.statistics_display?.footer_site_stats ? createUmamiStatsConfig(_umami) : null;
+  _umami?.enabled && _umami.statistics_display?.token && _umami.statistics_display?.footer_site_stats
+    ? createUmamiStatsConfig(_umami)
+    : null;
 
-/** Create per-page article stats config. Returns null when article pageviews are disabled. */
+/** Create per-page article stats config. Returns null when disabled or token missing. */
 export function createArticleStatsConfig(href: string): UmamiStatsConfig | null {
-  return _umami?.enabled && _umami.statistics_display?.article_page_views ? createUmamiStatsConfig(_umami, href) : null;
+  return _umami?.enabled && _umami.statistics_display?.token && _umami.statistics_display?.article_page_views
+    ? createUmamiStatsConfig(_umami, href)
+    : null;
 }
 
 // Map YAML christmas config with defaults

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -1,6 +1,7 @@
 // Import YAML config directly - processed by @rollup/plugin-yaml
 
 import type {
+  AnalyticsConfig,
   BangumiConfig,
   BgmAudioGroup,
   CommentConfig,
@@ -12,6 +13,8 @@ import type {
   SiteBasicConfig,
 } from '@lib/config/types';
 import { DEFAULT_TIMEZONE, isValidTimezone } from '@lib/timezone';
+import { createUmamiStatsConfig } from '@lib/umami-stats';
+import type { UmamiStatsConfig } from '@/types/umami-stats';
 import yamlConfig from '../../config/site.yaml';
 import { routers as baseRouters, isReservedSlug, RESERVED_ROUTES } from './router';
 
@@ -218,20 +221,7 @@ export const seoConfig = {
 const BUILT_IN_COVERS = Array.from({ length: 21 }, (_, i) => `/img/cover/${i + 1}.webp`);
 export const defaultCoverList = yamlConfig?.defaultCoverList?.length ? yamlConfig.defaultCoverList : BUILT_IN_COVERS;
 
-// Analytics config types
-type AnalyticsConfig = {
-  umami?: {
-    enabled: boolean;
-    id: string;
-    endpoint: string;
-    statistics_display?: {
-      token: string;
-      loginType: 'classic' | 'shared';
-      article_page_views: boolean;
-      footer_site_stats: boolean;
-    };
-  };
-};
+// Analytics config — reuses AnalyticsConfig from config/types.ts
 
 // Christmas config types
 type ChristmasConfig = {
@@ -279,6 +269,17 @@ export const contentConfig: ContentConfig = yamlConfig.content || {};
 
 // Map YAML analytics config
 export const analyticsConfig: AnalyticsConfig = yamlConfig.analytics || {};
+
+const _umami = analyticsConfig?.umami;
+
+/** Pre-computed site-wide pageview stats config. null when disabled. */
+export const umamiSiteStatsConfig: UmamiStatsConfig | null =
+  _umami?.enabled && _umami.statistics_display?.footer_site_stats ? createUmamiStatsConfig(_umami) : null;
+
+/** Create per-page article stats config. Returns null when article pageviews are disabled. */
+export function createArticleStatsConfig(href: string): UmamiStatsConfig | null {
+  return _umami?.enabled && _umami.statistics_display?.article_page_views ? createUmamiStatsConfig(_umami, href) : null;
+}
 
 // Map YAML christmas config with defaults
 export const christmasConfig: ChristmasConfig = yamlConfig.christmas || {

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -224,6 +224,12 @@ type AnalyticsConfig = {
     enabled: boolean;
     id: string;
     endpoint: string;
+    statistics_display?: {
+      token: string;
+      loginType: 'classic' | 'shared';
+      article_page_views: boolean;
+      footer_site_stats: boolean;
+    };
   };
 };
 

--- a/src/hooks/useCurrentHeading.ts
+++ b/src/hooks/useCurrentHeading.ts
@@ -89,13 +89,13 @@ function createHeadingStore(offsetTop: number) {
     let closestTop = Number.POSITIVE_INFINITY;
     let closestElement: HTMLElement | null = null;
 
-    visibleHeadings.forEach(({ top, element }, id) => {
+    for (const [id, { top, element }] of visibleHeadings) {
       if (top < closestTop) {
         closestTop = top;
         closestId = id;
         closestElement = element;
       }
-    });
+    }
 
     if (closestElement && closestId) {
       const level = parseInt(closestElement.tagName.substring(1), 10) as 2 | 3;

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -175,7 +175,9 @@ export const uiStrings: UIStrings = {
   'footer.runningDays': 'Running for {days} days',
   'footer.wordUnit': 'words',
   'footer.postUnit': 'posts',
-  'footer.pageviews': 'Page views',
+
+  // ── Analytics Stats ─────────────────────────────────────────
+  'stats.pageviews': 'Page views',
 
   // ── Pagination ──────────────────────────────────────────────
   'pagination.prev': 'Previous',

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -175,6 +175,7 @@ export const uiStrings: UIStrings = {
   'footer.runningDays': 'Running for {days} days',
   'footer.wordUnit': 'words',
   'footer.postUnit': 'posts',
+  'footer.pageviews': 'Page views',
 
   // ── Pagination ──────────────────────────────────────────────
   'pagination.prev': 'Previous',

--- a/src/i18n/translations/ja.ts
+++ b/src/i18n/translations/ja.ts
@@ -175,7 +175,9 @@ export const uiStrings: UIStrings = {
   'footer.runningDays': '稼働して{days}日が経過',
   'footer.wordUnit': '文字',
   'footer.postUnit': '投稿',
-  'footer.pageviews': 'アクセス数',
+
+  // ── Analytics Stats ─────────────────────────────────────────
+  'stats.pageviews': 'アクセス数',
 
   // ── ページ付け ──────────────────────────────────────────────
   'pagination.prev': '前へ',

--- a/src/i18n/translations/ja.ts
+++ b/src/i18n/translations/ja.ts
@@ -175,6 +175,7 @@ export const uiStrings: UIStrings = {
   'footer.runningDays': '稼働して{days}日が経過',
   'footer.wordUnit': '文字',
   'footer.postUnit': '投稿',
+  'footer.pageviews': 'アクセス数',
 
   // ── ページ付け ──────────────────────────────────────────────
   'pagination.prev': '前へ',

--- a/src/i18n/translations/zh.ts
+++ b/src/i18n/translations/zh.ts
@@ -174,7 +174,9 @@ export const uiStrings = {
   'footer.runningDays': '已运行 {days} 天',
   'footer.wordUnit': '字',
   'footer.postUnit': '篇',
-  'footer.pageviews': '访问量',
+
+  // ── Analytics Stats ─────────────────────────────────────────
+  'stats.pageviews': '访问量',
 
   // ── Pagination ──────────────────────────────────────────────
   'pagination.prev': '上一页',

--- a/src/i18n/translations/zh.ts
+++ b/src/i18n/translations/zh.ts
@@ -174,6 +174,7 @@ export const uiStrings = {
   'footer.runningDays': '已运行 {days} 天',
   'footer.wordUnit': '字',
   'footer.postUnit': '篇',
+  'footer.pageviews': '访问量',
 
   // ── Pagination ──────────────────────────────────────────────
   'pagination.prev': '上一页',

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -439,6 +439,12 @@ export interface UmamiConfig {
   enabled: boolean;
   id: string;
   endpoint: string;
+  statistics_display?: {
+    token: string;
+    loginType: 'classic' | 'shared';
+    article_page_views: boolean;
+    footer_site_stats: boolean;
+  };
 }
 
 export interface AnalyticsConfig {

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -440,8 +440,8 @@ export interface UmamiConfig {
   id: string;
   endpoint: string;
   statistics_display?: {
+    /** Umami share link token (read-only, safe to expose on client) */
     token: string;
-    loginType: 'classic' | 'shared';
     article_page_views: boolean;
     footer_site_stats: boolean;
   };

--- a/src/lib/umami-stats.ts
+++ b/src/lib/umami-stats.ts
@@ -1,6 +1,8 @@
 import type { UmamiConfig } from '@lib/config/types';
 import type { UmamiSessionStats, UmamiStatsConfig } from '@/types/umami-stats';
 
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
 async function getSessionStats(config: UmamiStatsConfig): Promise<UmamiSessionStats> {
   const { baseUrl, websiteId, shareToken, path } = config;
 
@@ -19,25 +21,44 @@ async function getSessionStats(config: UmamiStatsConfig): Promise<UmamiSessionSt
   url.search = params.toString();
 
   const response = await fetch(url.toString(), { method: 'GET', headers });
-  const data = await response.json();
   if (!response.ok) {
-    throw new Error(`Umami API error: ${data?.message ?? response.statusText}`);
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(`Umami API error: ${text}`);
   }
-  return data;
+  return await response.json();
 }
 
-const inflightRequests = new Map<string, Promise<number | 'N/A'>>();
+interface CacheEntry {
+  value: number | null;
+  expiresAt: number;
+}
 
-export function getPageviews(config: UmamiStatsConfig): Promise<number | 'N/A'> {
-  const key = `${config.baseUrl}:${config.websiteId}:${config.path ?? ''}`;
+const cache = new Map<string, CacheEntry>();
+const inflightRequests = new Map<string, Promise<number | null>>();
+
+function getCacheKey(config: UmamiStatsConfig): string {
+  return `${config.baseUrl}:${config.websiteId}:${config.path ?? ''}`;
+}
+
+export function getPageviews(config: UmamiStatsConfig): Promise<number | null> {
+  const key = getCacheKey(config);
+
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return Promise.resolve(cached.value);
+
   const inflight = inflightRequests.get(key);
   if (inflight) return inflight;
 
   const promise = getSessionStats(config)
-    .then((stats) => (typeof stats.pageviews === 'number' ? stats.pageviews : stats.pageviews.value))
+    .then((stats) => {
+      const pv = typeof stats.pageviews === 'number' ? stats.pageviews : stats.pageviews.value;
+      cache.set(key, { value: pv, expiresAt: Date.now() + CACHE_TTL });
+      return pv;
+    })
     .catch((error) => {
       console.error('Failed to fetch Umami pageviews:', error);
-      return 'N/A' as const;
+      cache.set(key, { value: null, expiresAt: Date.now() + CACHE_TTL });
+      return null;
     })
     .finally(() => inflightRequests.delete(key));
 
@@ -45,11 +66,16 @@ export function getPageviews(config: UmamiStatsConfig): Promise<number | 'N/A'> 
   return promise;
 }
 
+/** Normalize path to strip trailing slash for consistent Umami matching */
+function normalizePath(path: string): string {
+  return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
 export function createUmamiStatsConfig(config: UmamiConfig, path?: string): UmamiStatsConfig {
   return {
     baseUrl: config.endpoint,
     websiteId: config.id,
     shareToken: config.statistics_display?.token ?? '',
-    path,
+    path: path ? normalizePath(path) : undefined,
   };
 }

--- a/src/lib/umami-stats.ts
+++ b/src/lib/umami-stats.ts
@@ -78,11 +78,13 @@ function normalizePath(path: string): string {
   return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
 }
 
-export function createUmamiStatsConfig(config: UmamiConfig, path?: string): UmamiStatsConfig {
+export function createUmamiStatsConfig(config: UmamiConfig, path?: string): UmamiStatsConfig | null {
+  const token = config.statistics_display?.token;
+  if (!token) return null;
   return {
     baseUrl: config.endpoint,
     websiteId: config.id,
-    shareToken: config.statistics_display?.token ?? '',
+    shareToken: token,
     path: path ? normalizePath(path) : undefined,
   };
 }

--- a/src/lib/umami-stats.ts
+++ b/src/lib/umami-stats.ts
@@ -1,65 +1,55 @@
-/**
- * 获取 Umami Session Stats
- * @param UmamiSessionStatsConfig
- * @returns
- */
-
 import type { UmamiConfig } from '@lib/config/types';
-import type { UmamiSessionStats, UmamiSessionStatsConfig } from '@/types/umami-stats';
+import type { UmamiSessionStats, UmamiStatsConfig } from '@/types/umami-stats';
 
-const getSessionStats = async (config: UmamiSessionStatsConfig): Promise<UmamiSessionStats> => {
-  const { baseUrl, websiteId, token, loginType = 'classic', path } = config;
+async function getSessionStats(config: UmamiStatsConfig): Promise<UmamiSessionStats> {
+  const { baseUrl, websiteId, shareToken, path } = config;
 
   const url = new URL(baseUrl);
   url.pathname = `/api/websites/${websiteId}/stats`;
 
-  const headers = new Headers();
-  headers.append('accept', 'application/json');
-  if (loginType === 'classic') {
-    headers.append('Authorization', `Bearer ${token}`);
-  } else if (loginType === 'shared') {
-    headers.append('x-umami-share-token', token);
-  } else {
-    throw new Error('loginType must be classic or shared');
-  }
+  const headers = new Headers({
+    accept: 'application/json',
+    'x-umami-share-token': shareToken,
+  });
 
   const params = new URLSearchParams();
   params.append('startAt', config.startAt?.toString() || '0');
   params.append('endAt', config.endAt?.toString() || Date.now().toString());
-  path && params.append('path', encodeURI(path));
+  if (path) params.append('path', path);
   url.search = params.toString();
 
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    headers,
-  });
+  const response = await fetch(url.toString(), { method: 'GET', headers });
   const data = await response.json();
   if (!response.ok) {
-    throw new Error(`Error: ${data.data?.error}`);
+    throw new Error(`Umami API error: ${data?.message ?? response.statusText}`);
   }
   return data;
-};
+}
 
-const safeGetPageviews = async (config: UmamiSessionStatsConfig): Promise<number | 'N/A'> => {
-  try {
-    const stats = await getSessionStats(config);
-    if (typeof stats.pageviews === 'number') {
-      return stats.pageviews;
-    } else {
-      return stats.pageviews.value;
-    }
-  } catch (error) {
-    console.error('Error fetching Umami Pageviews:', error);
-    return 'N/A';
-  }
-};
+const inflightRequests = new Map<string, Promise<number | 'N/A'>>();
 
-const UmamiConfigToSessionStatsConfig = (config: UmamiConfig, path?: string): UmamiSessionStatsConfig => ({
-  baseUrl: config.endpoint || '',
-  websiteId: config.id || '',
-  token: config.statistics_display?.token || '',
-  loginType: config.statistics_display?.loginType || 'classic',
-  path,
-});
+export function getPageviews(config: UmamiStatsConfig): Promise<number | 'N/A'> {
+  const key = `${config.baseUrl}:${config.websiteId}:${config.path ?? ''}`;
+  const inflight = inflightRequests.get(key);
+  if (inflight) return inflight;
 
-export { getSessionStats, safeGetPageviews, UmamiConfigToSessionStatsConfig };
+  const promise = getSessionStats(config)
+    .then((stats) => (typeof stats.pageviews === 'number' ? stats.pageviews : stats.pageviews.value))
+    .catch((error) => {
+      console.error('Failed to fetch Umami pageviews:', error);
+      return 'N/A' as const;
+    })
+    .finally(() => inflightRequests.delete(key));
+
+  inflightRequests.set(key, promise);
+  return promise;
+}
+
+export function createUmamiStatsConfig(config: UmamiConfig, path?: string): UmamiStatsConfig {
+  return {
+    baseUrl: config.endpoint,
+    websiteId: config.id,
+    shareToken: config.statistics_display?.token ?? '',
+    path,
+  };
+}

--- a/src/lib/umami-stats.ts
+++ b/src/lib/umami-stats.ts
@@ -7,7 +7,8 @@ async function getSessionStats(config: UmamiStatsConfig): Promise<UmamiSessionSt
   const { baseUrl, websiteId, shareToken, path } = config;
 
   const url = new URL(baseUrl);
-  url.pathname = `/api/websites/${websiteId}/stats`;
+  const basePath = url.pathname.replace(/\/$/, '');
+  url.pathname = `${basePath}/api/websites/${encodeURIComponent(websiteId)}/stats`;
 
   const headers = new Headers({
     accept: 'application/json',

--- a/src/lib/umami-stats.ts
+++ b/src/lib/umami-stats.ts
@@ -1,0 +1,65 @@
+/**
+ * 获取 Umami Session Stats
+ * @param UmamiSessionStatsConfig
+ * @returns
+ */
+
+import type { UmamiConfig } from '@lib/config/types';
+import type { UmamiSessionStats, UmamiSessionStatsConfig } from '@/types/umami-stats';
+
+const getSessionStats = async (config: UmamiSessionStatsConfig): Promise<UmamiSessionStats> => {
+  const { baseUrl, websiteId, token, loginType = 'classic', path } = config;
+
+  const url = new URL(baseUrl);
+  url.pathname = `/api/websites/${websiteId}/stats`;
+
+  const headers = new Headers();
+  headers.append('accept', 'application/json');
+  if (loginType === 'classic') {
+    headers.append('Authorization', `Bearer ${token}`);
+  } else if (loginType === 'shared') {
+    headers.append('x-umami-share-token', token);
+  } else {
+    throw new Error('loginType must be classic or shared');
+  }
+
+  const params = new URLSearchParams();
+  params.append('startAt', config.startAt?.toString() || '0');
+  params.append('endAt', config.endAt?.toString() || Date.now().toString());
+  path && params.append('path', encodeURI(path));
+  url.search = params.toString();
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers,
+  });
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(`Error: ${data.data?.error}`);
+  }
+  return data;
+};
+
+const safeGetPageviews = async (config: UmamiSessionStatsConfig): Promise<number | 'N/A'> => {
+  try {
+    const stats = await getSessionStats(config);
+    if (typeof stats.pageviews === 'number') {
+      return stats.pageviews;
+    } else {
+      return stats.pageviews.value;
+    }
+  } catch (error) {
+    console.error('Error fetching Umami Pageviews:', error);
+    return 'N/A';
+  }
+};
+
+const UmamiConfigToSessionStatsConfig = (config: UmamiConfig, path?: string): UmamiSessionStatsConfig => ({
+  baseUrl: config.endpoint || '',
+  websiteId: config.id || '',
+  token: config.statistics_display?.token || '',
+  loginType: config.statistics_display?.loginType || 'classic',
+  path,
+});
+
+export { getSessionStats, safeGetPageviews, UmamiConfigToSessionStatsConfig };

--- a/src/lib/umami-stats.ts
+++ b/src/lib/umami-stats.ts
@@ -15,6 +15,7 @@ async function getSessionStats(config: UmamiStatsConfig): Promise<UmamiSessionSt
   });
 
   const params = new URLSearchParams();
+  // Default to Unix epoch (all-time stats)
   params.append('startAt', config.startAt?.toString() || '0');
   params.append('endAt', config.endAt?.toString() || Date.now().toString());
   if (path) params.append('path', path);
@@ -57,6 +58,11 @@ export function getPageviews(config: UmamiStatsConfig): Promise<number | null> {
     })
     .catch((error) => {
       console.error('Failed to fetch Umami pageviews:', error);
+      if (import.meta.env.DEV) {
+        console.warn(
+          `[umami-stats] Fetch failed for key "${key}". Check that your Umami endpoint, website ID, and share token are correct in config/site.yaml.`,
+        );
+      }
       cache.set(key, { value: null, expiresAt: Date.now() + CACHE_TTL });
       return null;
     })

--- a/src/types/umami-stats.ts
+++ b/src/types/umami-stats.ts
@@ -1,83 +1,29 @@
-// Umami Session Stats type
-
-// Umami 的不同版本 api 返回的数据结构是不同的
-// 但一般都含有以下字段：
-// pageviews: 页面访问量
-// visitors: 访问者数量
+/** Different Umami API versions may return either a raw number or { value: number } */
+type UmamiValue = { value: number } | number;
 
 export interface UmamiSessionStats {
-  pageviews:
-    | {
-        value: number;
-      }
-    | number;
-  visitors:
-    | {
-        value: number;
-      }
-    | number;
-  visits?:
-    | {
-        value: number;
-      }
-    | number;
-  countries?:
-    | {
-        value: number;
-      }
-    | number;
-  events?:
-    | {
-        value: number;
-      }
-    | number;
-  bounces?:
-    | {
-        value: number;
-      }
-    | number;
-  totaltime?:
-    | {
-        value: number;
-      }
-    | number;
+  pageviews: UmamiValue;
+  visitors: UmamiValue;
+  visits?: UmamiValue;
+  countries?: UmamiValue;
+  events?: UmamiValue;
+  bounces?: UmamiValue;
+  totaltime?: UmamiValue;
   comparison?: {
-    pageviews?:
-      | {
-          value: number;
-        }
-      | number;
-    visitors?:
-      | {
-          value: number;
-        }
-      | number;
-    visits?:
-      | {
-          value: number;
-        }
-      | number;
-    bounces?:
-      | {
-          value: number;
-        }
-      | number;
-    totaltime?:
-      | {
-          value: number;
-        }
-      | number;
+    pageviews?: UmamiValue;
+    visitors?: UmamiValue;
+    visits?: UmamiValue;
+    bounces?: UmamiValue;
+    totaltime?: UmamiValue;
   };
 }
 
-export interface UmamiSessionStatsConfig {
+export interface UmamiStatsConfig {
   baseUrl: string;
   websiteId: string;
-  token: string;
-  // login 方式
-  loginType?: 'classic' | 'shared';
+  /** Umami share link token (read-only, safe to expose on client) */
+  shareToken: string;
   path?: string;
-  // 时间范围
   startAt?: number;
   endAt?: number;
 }

--- a/src/types/umami-stats.ts
+++ b/src/types/umami-stats.ts
@@ -1,0 +1,83 @@
+// Umami Session Stats type
+
+// Umami 的不同版本 api 返回的数据结构是不同的
+// 但一般都含有以下字段：
+// pageviews: 页面访问量
+// visitors: 访问者数量
+
+export interface UmamiSessionStats {
+  pageviews:
+    | {
+        value: number;
+      }
+    | number;
+  visitors:
+    | {
+        value: number;
+      }
+    | number;
+  visits?:
+    | {
+        value: number;
+      }
+    | number;
+  countries?:
+    | {
+        value: number;
+      }
+    | number;
+  events?:
+    | {
+        value: number;
+      }
+    | number;
+  bounces?:
+    | {
+        value: number;
+      }
+    | number;
+  totaltime?:
+    | {
+        value: number;
+      }
+    | number;
+  comparison?: {
+    pageviews?:
+      | {
+          value: number;
+        }
+      | number;
+    visitors?:
+      | {
+          value: number;
+        }
+      | number;
+    visits?:
+      | {
+          value: number;
+        }
+      | number;
+    bounces?:
+      | {
+          value: number;
+        }
+      | number;
+    totaltime?:
+      | {
+          value: number;
+        }
+      | number;
+  };
+}
+
+export interface UmamiSessionStatsConfig {
+  baseUrl: string;
+  websiteId: string;
+  token: string;
+  // login 方式
+  loginType?: 'classic' | 'shared';
+  path?: string;
+  // 时间范围
+  startAt?: number;
+  endAt?: number;
+}

--- a/src/types/umami-stats.ts
+++ b/src/types/umami-stats.ts
@@ -3,19 +3,7 @@ type UmamiValue = { value: number } | number;
 
 export interface UmamiSessionStats {
   pageviews: UmamiValue;
-  visitors: UmamiValue;
-  visits?: UmamiValue;
-  countries?: UmamiValue;
-  events?: UmamiValue;
-  bounces?: UmamiValue;
-  totaltime?: UmamiValue;
-  comparison?: {
-    pageviews?: UmamiValue;
-    visitors?: UmamiValue;
-    visits?: UmamiValue;
-    bounces?: UmamiValue;
-    totaltime?: UmamiValue;
-  };
+  [key: string]: unknown;
 }
 
 export interface UmamiStatsConfig {


### PR DESCRIPTION
## Summary

- Add client-side Umami pageview statistics display (article cards, article cover, footer site stats) using share-link token for read-only access
- Add Japanese (ja) locale translations for bangumi section and analytics stats
- Refine layout: reduce default scrollbar width, adjust sidebar/TOC/series-list padding for better spacing

## Changed Files

| File | Change |
|------|--------|
| `config/site.yaml` | Add `statistics_display` config under `analytics.umami` |
| `src/lib/config/types.ts` | Extend `UmamiConfig` type with `statistics_display` |
| `src/types/umami-stats.ts` | **New** — Umami stats types (`UmamiStatsConfig`, `UmamiSessionStats`) |
| `src/lib/umami-stats.ts` | **New** — API client with request dedup and config factory |
| `src/components/umami/UmamiPVSpan.tsx` | **New** — React component for async pageview display |
| `src/constants/site-config.ts` | Export `umamiSiteStatsConfig`, `createArticleStatsConfig` |
| `src/components/layout/Footer.astro` | Show site-wide pageviews in footer |
| `src/components/post/PostItemCard.astro` | Show per-article pageviews on post cards |
| `src/components/ui/cover/Cover.astro` | Show per-article pageviews on article cover |
| `src/i18n/translations/{zh,en,ja}.ts` | Add `stats.pageviews` key; ja: full bangumi translations |
| `src/styles/global/tailwind.css` | Reduce default scrollbar width (0.5rem → 0.25rem) |
| `src/components/layout/{HomeInfo,HomeSider,TableOfContents,SeriesPostList}` | Minor padding/spacing tweaks |

## Test Plan

- [ ] Verify pageview counts render correctly when Umami is configured with valid token
- [ ] Verify graceful fallback ("N/A") when Umami API is unreachable
- [ ] Verify no stats UI appears when `analytics.umami.enabled: false`
- [ ] Check footer, post cards, and article cover all display consistently
- [ ] Verify Japanese translations render correctly
- [ ] Confirm scrollbar and layout spacing look correct across breakpoints