### PR TITLE
refactor: 删除 Layout.astro 中无用的预连接第三方域名资源提示

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -86,13 +86,6 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="generator" content={Astro.generator} />
-    
-    <!-- Preconnect to third-party origins for faster resource loading -->
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-    <link rel="dns-prefetch" href="https://cdn.jsdelivr.net" />
-    <link rel="preconnect" href="https://chinese-font.netlify.app" crossorigin />
-    <link rel="dns-prefetch" href="https://chinese-font.netlify.app" />
-
     {/* Async load rounded fonts — Japanese pages use Gen Jyuu Gothic P, others use ChillRoundF (fix #113) */}
     {locale === 'ja' ? (
       <>


### PR DESCRIPTION
这两个域名压根就不会出现，这部分预连接代码完全无意义