### PR TITLE
fix: 修复 React Grab 总是被启用问题

### DIFF
--- a/src/components/dev/ReactGrabInit.tsx
+++ b/src/components/dev/ReactGrabInit.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+// react-grab: dev-only tool for copying React component context (file, component name, HTML)
+// This component is only rendered when REACT_GRAB=true is set in .env
+export default function ReactGrabInit() {
+  useEffect(() => {
+    import('react-grab');
+  }, []);
+
+  return null;
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ import { ClientRouter } from 'astro:transitions';
 import AnnouncementProvider from '@components/announcement/AnnouncementProvider.astro';
 import GlobalBGMPlayer from '@components/bgm/GlobalBGMPlayer';
 import ChristmasEffects from '@components/christmas/ChristmasEffects.astro';
+import ReactGrabInit from '@components/dev/ReactGrabInit';
 import FloatingGroup from '@components/layout/FloatingGroup';
 import Header from '@components/layout/Header.astro';
 import MobileDrawer from '@components/layout/MobileDrawer.astro';
@@ -197,11 +198,7 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
       })();
     </script>
 
-    {enableReactGrab && (
-      <script>
-        import('react-grab');
-      </script>
-    )}
+    {enableReactGrab && <ReactGrabInit client:load />}
 
     <!-- 子页面可通过 slot="head" 注入额外的 head 内容（如 JSON-LD） -->
     <slot name="head" />


### PR DESCRIPTION
## 修复方案

1. **移除**内联的 `<script>import('react-grab')</script>` 块
2. 改为渲染一个 React 组件，通过 `client:load` 指令按需加载