### PR TITLE
fix: adapt Umami Cloud share stats API

### DIFF
--- a/src/lib/umami-stats.ts
+++ b/src/lib/umami-stats.ts
@@ -3,47 +3,111 @@ import type { UmamiSessionStats, UmamiStatsConfig } from '@/types/umami-stats';
 
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
-// Share slug -> JWT token cache (JWT is short-lived, refresh every 30 min)
-const JWT_CACHE_TTL = 30 * 60 * 1000;
-let jwtCache: { token: string; expiresAt: number; key: string } | null = null;
+// Share slug -> resolved share metadata cache (JWT is short-lived, refresh every 30 min)
+const SHARE_DATA_CACHE_TTL = 30 * 60 * 1000;
 
-/** Exchange a share slug for a JWT token via GET /api/share/<slug> */
-async function resolveShareToken(baseUrl: string, shareSlug: string): Promise<string> {
-  const key = `${baseUrl}:${shareSlug}`;
-  if (jwtCache && jwtCache.key === key && jwtCache.expiresAt > Date.now()) {
-    return jwtCache.token;
+interface UmamiShareData {
+  token: string;
+  websiteId?: string;
+  apiBaseUrl: string;
+}
+
+let shareDataCache: { value: UmamiShareData; expiresAt: number; key: string } | null = null;
+
+function getApiBaseUrlCandidates(baseUrl: string): string[] {
+  const url = new URL(baseUrl);
+  const normalizedBaseUrl = url.toString().replace(/\/+$/, '');
+  const candidates = [normalizedBaseUrl];
+
+  // Umami Cloud serves public share APIs under /analytics/us while the tracker
+  // script remains at https://cloud.umami.is/script.js. Keep self-hosted
+  // endpoints unchanged, but always try the current Cloud app API path first.
+  if (url.hostname === 'cloud.umami.is') {
+    candidates.unshift(`${url.origin}/analytics/us`);
   }
 
-  const url = new URL(baseUrl);
+  return [...new Set(candidates)];
+}
+
+function createApiUrl(apiBaseUrl: string, path: string): URL {
+  const url = new URL(apiBaseUrl);
   const basePath = url.pathname.replace(/\/$/, '');
-  url.pathname = `${basePath}/api/share/${encodeURIComponent(shareSlug)}`;
+  url.pathname = `${basePath}${path}`;
+  return url;
+}
+
+function isJsonResponse(response: Response): boolean {
+  return response.headers.get('content-type')?.includes('application/json') ?? false;
+}
+
+async function fetchShareData(apiBaseUrl: string, shareSlug: string): Promise<UmamiShareData | null> {
+  const url = createApiUrl(apiBaseUrl, `/api/share/${encodeURIComponent(shareSlug)}`);
 
   const response = await fetch(url.toString(), {
     method: 'GET',
     headers: { accept: 'application/json' },
   });
 
+  if (response.status === 404) return null;
   if (!response.ok) {
-    throw new Error(`Failed to resolve share token: ${response.status} ${response.statusText}`);
+    throw new Error(`Failed to resolve Umami share token: ${response.status} ${response.statusText}`);
+  }
+  if (!isJsonResponse(response)) {
+    throw new Error(`Unexpected Umami share response content type: ${response.headers.get('content-type') ?? 'unknown'}`);
   }
 
-  const data: { token: string; websiteId: string } = await response.json();
-  jwtCache = { token: data.token, expiresAt: Date.now() + JWT_CACHE_TTL, key };
-  return data.token;
+  const data: { token?: string; websiteId?: string } = await response.json();
+  if (!data.token) throw new Error('Umami share response did not include a token');
+
+  return {
+    token: data.token,
+    websiteId: data.websiteId,
+    apiBaseUrl,
+  };
+}
+
+/** Exchange a share slug for short-lived share metadata via GET /api/share/<slug>. */
+async function resolveShareData(baseUrl: string, shareSlug: string): Promise<UmamiShareData> {
+  const key = `${baseUrl}:${shareSlug}`;
+  if (shareDataCache && shareDataCache.key === key && shareDataCache.expiresAt > Date.now()) {
+    return shareDataCache.value;
+  }
+
+  for (const apiBaseUrl of getApiBaseUrlCandidates(baseUrl)) {
+    const shareData = await fetchShareData(apiBaseUrl, shareSlug);
+    if (!shareData) continue;
+
+    shareDataCache = { value: shareData, expiresAt: Date.now() + SHARE_DATA_CACHE_TTL, key };
+    return shareData;
+  }
+
+  throw new Error('Failed to resolve Umami share token: no compatible share API endpoint responded');
+}
+
+function getWebsiteId(configuredWebsiteId: string, shareData: UmamiShareData): string {
+  if (!shareData.websiteId) return configuredWebsiteId;
+
+  if (shareData.websiteId !== configuredWebsiteId && import.meta.env.DEV) {
+    console.warn(
+      `[umami-stats] Configured website ID "${configuredWebsiteId}" differs from the website ID in the Umami share link "${shareData.websiteId}". Using the share-link website ID for stats requests.`,
+    );
+  }
+
+  return shareData.websiteId;
 }
 
 async function getSessionStats(config: UmamiStatsConfig): Promise<UmamiSessionStats> {
-  const { baseUrl, websiteId, shareToken: shareSlug, path } = config;
+  const { baseUrl, websiteId: configuredWebsiteId, shareToken: shareSlug, path } = config;
 
-  const jwt = await resolveShareToken(baseUrl, shareSlug);
-
-  const url = new URL(baseUrl);
-  const basePath = url.pathname.replace(/\/$/, '');
-  url.pathname = `${basePath}/api/websites/${encodeURIComponent(websiteId)}/stats`;
+  const shareData = await resolveShareData(baseUrl, shareSlug);
+  const websiteId = getWebsiteId(configuredWebsiteId, shareData);
+  const url = createApiUrl(shareData.apiBaseUrl, `/api/websites/${encodeURIComponent(websiteId)}/stats`);
 
   const headers = new Headers({
     accept: 'application/json',
-    'x-umami-share-token': jwt,
+    'x-umami-share-token': shareData.token,
+    // Required by current Umami auth when a share token is used from the public share flow.
+    'x-umami-share-context': '1',
   });
 
   const params = new URLSearchParams();
@@ -70,7 +134,9 @@ const cache = new Map<string, CacheEntry>();
 const inflightRequests = new Map<string, Promise<number | null>>();
 
 function getCacheKey(config: UmamiStatsConfig): string {
-  return `${config.baseUrl}:${config.websiteId}:${config.path ?? ''}`;
+  return [config.baseUrl, config.websiteId, config.shareToken, config.path ?? '', config.startAt ?? 0, config.endAt ?? ''].join(
+    ':',
+  );
 }
 
 export function getPageviews(config: UmamiStatsConfig): Promise<number | null> {


### PR DESCRIPTION
## Summary

Fix Umami pageview stats retrieval for current Umami Cloud public share pages/API.

This update makes the stats reader work with the current Umami Cloud share flow by:

- resolving share metadata from `/api/share/<slug>`
- preferring the current Umami Cloud app API base (`/analytics/us`) when the base URL points to `cloud.umami.is`
- sending the required `x-umami-share-context: 1` header for share-token stats requests
- using the `websiteId` returned by the share API when available
- expanding cache keys so different share/config combinations do not collide

## Why

The previous implementation assumed the share token and stats API could be resolved from a simpler root-path flow. That no longer matches the current Umami Cloud share page/API behavior, so pageview stats could fail in production for Cloud share links.

## Validation

- `pnpm exec biome check src/lib/umami-stats.ts`
- `pnpm build`
- manual runtime verification against Umami Cloud share pages
- local browser test confirmed Umami pageview display works correctly

## Notes

- This change is intentionally scoped to `src/lib/umami-stats.ts`
- Existing unrelated `pnpm check` issues in the repo were not changed by this PR
