### PR TITLE
docs: 更新[使用本主题的博客]中的Ksable仓库地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ comment:
 | ----------------------------------------- | ---------- | --------------------------------------------------------------- | ---------------------------- |
 | **[余弦の博客](http://blog.cosine.ren/)** | **cosine** | [cosZone/astro-koharu](https://github.com/cosZone/astro-koharu) | 本主题                       |
 | [雪花的博客](https://xhblog.top/)         | XueHua-s   | [XueHua-s/astro-snow](https://github.com/XueHua-s/astro-snow)   | 精简了很多功能，增加了起始页 |
-| [Ksable's 小屋](https://blog.ksable.top/) | Ksable    | - | 修改 / 新增了部分功能 |
+| [Ksable's 小屋](https://blog.ksable.top/) | Ksable    | [God-2077/astro-blog](https://github.com/God-2077/astro-blog) | 修改 / 新增了部分功能 |
 
 ## 🙏 鸣谢
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -330,7 +330,7 @@ comment:
 | -------------------------------------------- | ---------- | --------------------------------------------------------------- | --------------------------------------- |
 | **[Cosine's Blog](http://blog.cosine.ren/)** | **cosine** | [cosZone/astro-koharu](https://github.com/cosZone/astro-koharu) | This theme                              |
 | [XueHua's Blog](https://xhblog.top/)         | XueHua-s   | [XueHua-s/astro-snow](https://github.com/XueHua-s/astro-snow)   | Simplified features, added a start page |
-| [Ksable's Blog](https://blog.ksable.top/)    | Ksable     | -                                                               | Modified / added some features          |
+| [Ksable's Blog](https://blog.ksable.top/)    | Ksable     | [God-2077/astro-blog](https://github.com/God-2077/astro-blog) | Modified / added some features          |
 
 ## Acknowledgements
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -330,7 +330,7 @@ comment:
 | ---------------------------------------------- | ---------- | --------------------------------------------------------------- | -------------------------------------- |
 | **[Cosine のブログ](http://blog.cosine.ren/)** | **cosine** | [cosZone/astro-koharu](https://github.com/cosZone/astro-koharu) | このテーマ                              |
 | [XueHua のブログ](https://xhblog.top/)         | XueHua-s   | [XueHua-s/astro-snow](https://github.com/XueHua-s/astro-snow)   | 機能を簡素化、スタートページを追加      |
-| [Ksable's 小屋](https://blog.ksable.top/)      | Ksable     | -                                                               | 一部機能を変更 / 追加                  |
+| [Ksable's 小屋](https://blog.ksable.top/)      | Ksable     | [God-2077/astro-blog](https://github.com/God-2077/astro-blog)  | 一部機能を変更 / 追加                  |
 
 ## 謝辞
 


### PR DESCRIPTION
更新了英文、日文文档和中文README里的Ksable的博客仓库链接，修正为实际使用的God-2077/astro-blog仓库