### PR TITLE
v4.1.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+The Astro application lives in `src/`. Routes are in `src/pages/`; reusable Astro and React UI belongs in `src/components/`; layouts, hooks, utilities, Nanostores, and translations use matching directories. Blog content is under `src/content/blog/`, and static files are in `public/`. Configure the site in `config/site.yaml`. Build-time generators live in `src/scripts/`, the Koharu CLI in `scripts/`, and the standalone React/Vite CMS in `cms/`. Treat `dist/` and `.astro/` as generated output.
+
+## Build, Test, and Development Commands
+
+Use pnpm from the repository root:
+
+- `pnpm install` installs application dependencies.
+- `pnpm dev` starts Astro at `http://localhost:4321`.
+- `pnpm build` creates the production site; `pnpm preview` serves it.
+- `pnpm check` runs Astro and TypeScript validation.
+- `pnpm lint` checks source with Biome; `pnpm lint:fix` applies safe fixes.
+- `pnpm knip` reports unused files, exports, and dependencies.
+- `pnpm cms:install && pnpm cms` installs and starts the local CMS.
+- `pnpm koharu generate all` refreshes LQIP, summary, and similarity assets after relevant content changes.
+
+## Coding Style & Naming Conventions
+
+Biome is authoritative: two-space indentation, LF endings, 128-column lines, single quotes in JavaScript/TypeScript, semicolons, and trailing commas. Keep Tailwind classes sorted. Use PascalCase for React components (`PostCard.tsx`), `use`-prefixed camelCase for hooks (`useMediaQuery.ts`), and `index.ts` for intentional barrel exports. Prefer `.astro` for static layouts and pages; use React for interactive state. Import through aliases such as `@components/*` and `@lib/*`, and avoid circular dependencies.
+
+## Testing Guidelines
+
+There is currently no automated test script or coverage threshold. Before submitting changes, run `pnpm lint`, `pnpm check`, and `pnpm build`. Manually exercise affected routes and interactive components with `pnpm dev`; CMS changes should also be verified through `pnpm cms`. When adding test infrastructure, prioritize content utilities, transformations, scripts, hooks, and stores, using `*.test.ts` or `*.test.tsx` names.
+
+## Commit & Pull Request Guidelines
+
+Recent history favors short imperative subjects and Conventional Commit prefixes such as `fix:`, `feat:`, and `chore:`. Keep each commit focused and include generated assets when the source change requires them. Pull requests should explain the user-visible effect, list validation commands, link related issues, and include screenshots or recordings for visual changes. Call out configuration, migration, performance, or i18n impact explicitly.
+
+## Configuration & Generated Data
+
+Do not commit secrets from `.env`. Restart the dev server after changing `config/site.yaml`. Preserve the tracked `.cache/og-data.json`; it is an intentional build cache, unlike other ignored cache artifacts.

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ comment:
 | ----------------------------------------- | ---------- | --------------------------------------------------------------- | ---------------------------- |
 | **[余弦の博客](http://blog.cosine.ren/)** | **cosine** | [cosZone/astro-koharu](https://github.com/cosZone/astro-koharu) | 本主题                       |
 | [雪花的博客](https://xhblog.top/)         | XueHua-s   | [XueHua-s/astro-snow](https://github.com/XueHua-s/astro-snow)   | 精简了很多功能，增加了起始页 |
-| [Ksable's 小屋](https://blog.ksable.top/) | Ksable    | - | 修改 / 新增了部分功能 |
+| [Ksable's 小屋](https://blog.ksable.top/) | Ksable    | [God-2077/astro-blog](https://github.com/God-2077/astro-blog) | 修改 / 新增了部分功能 |
 
 ## 🙏 鸣谢
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -330,7 +330,7 @@ comment:
 | -------------------------------------------- | ---------- | --------------------------------------------------------------- | --------------------------------------- |
 | **[Cosine's Blog](http://blog.cosine.ren/)** | **cosine** | [cosZone/astro-koharu](https://github.com/cosZone/astro-koharu) | This theme                              |
 | [XueHua's Blog](https://xhblog.top/)         | XueHua-s   | [XueHua-s/astro-snow](https://github.com/XueHua-s/astro-snow)   | Simplified features, added a start page |
-| [Ksable's Blog](https://blog.ksable.top/)    | Ksable     | -                                                               | Modified / added some features          |
+| [Ksable's Blog](https://blog.ksable.top/)    | Ksable     | [God-2077/astro-blog](https://github.com/God-2077/astro-blog) | Modified / added some features          |
 
 ## Acknowledgements
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -330,7 +330,7 @@ comment:
 | ---------------------------------------------- | ---------- | --------------------------------------------------------------- | -------------------------------------- |
 | **[Cosine のブログ](http://blog.cosine.ren/)** | **cosine** | [cosZone/astro-koharu](https://github.com/cosZone/astro-koharu) | このテーマ                              |
 | [XueHua のブログ](https://xhblog.top/)         | XueHua-s   | [XueHua-s/astro-snow](https://github.com/XueHua-s/astro-snow)   | 機能を簡素化、スタートページを追加      |
-| [Ksable's 小屋](https://blog.ksable.top/)      | Ksable     | -                                                               | 一部機能を変更 / 追加                  |
+| [Ksable's 小屋](https://blog.ksable.top/)      | Ksable     | [God-2077/astro-blog](https://github.com/God-2077/astro-blog)  | 一部機能を変更 / 追加                  |
 
 ## 謝辞
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-koharu",
   "type": "module",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "scripts": {
     "dev": "astro dev",
     "generate:lqips": "npx tsx src/scripts/generateLqips.ts",

--- a/src/i18n/translations/ja.ts
+++ b/src/i18n/translations/ja.ts
@@ -176,8 +176,8 @@ export const uiStrings: UIStrings = {
   'footer.wordUnit': '文字',
   'footer.postUnit': '投稿',
 
-  // ── Analytics Stats ─────────────────────────────────────────
-  'stats.pageviews': 'アクセス数',
+  // ── 解析の統計 ─────────────────────────────────────────
+  'stats.pageviews': 'ページビュー',
 
   // ── ページ付け ──────────────────────────────────────────────
   'pagination.prev': '前へ',
@@ -237,8 +237,8 @@ export const uiStrings: UIStrings = {
 
   // ── 暗号化されたブロック ─────────────────────────────────────────
   'encrypted.locked': '暗号化されたコンテンツ',
-  'encrypted.placeholder': 'パスワードを入力でロックを解除',
-  'encrypted.submit': 'ロックを解除',
+  'encrypted.placeholder': 'パスワードを入力で解除',
+  'encrypted.submit': '解除',
   'encrypted.incorrect': 'パスワードが間違っています',
 
   // ── 暗号化された投稿 ─────────────────────────────────────────

--- a/src/lib/umami-stats.ts
+++ b/src/lib/umami-stats.ts
@@ -3,47 +3,111 @@ import type { UmamiSessionStats, UmamiStatsConfig } from '@/types/umami-stats';
 
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
-// Share slug -> JWT token cache (JWT is short-lived, refresh every 30 min)
-const JWT_CACHE_TTL = 30 * 60 * 1000;
-let jwtCache: { token: string; expiresAt: number; key: string } | null = null;
+// Share slug -> resolved share metadata cache (JWT is short-lived, refresh every 30 min)
+const SHARE_DATA_CACHE_TTL = 30 * 60 * 1000;
 
-/** Exchange a share slug for a JWT token via GET /api/share/<slug> */
-async function resolveShareToken(baseUrl: string, shareSlug: string): Promise<string> {
-  const key = `${baseUrl}:${shareSlug}`;
-  if (jwtCache && jwtCache.key === key && jwtCache.expiresAt > Date.now()) {
-    return jwtCache.token;
+interface UmamiShareData {
+  token: string;
+  websiteId?: string;
+  apiBaseUrl: string;
+}
+
+let shareDataCache: { value: UmamiShareData; expiresAt: number; key: string } | null = null;
+
+function getApiBaseUrlCandidates(baseUrl: string): string[] {
+  const url = new URL(baseUrl);
+  const normalizedBaseUrl = url.toString().replace(/\/+$/, '');
+  const candidates = [normalizedBaseUrl];
+
+  // Umami Cloud serves public share APIs under /analytics/us while the tracker
+  // script remains at https://cloud.umami.is/script.js. Keep self-hosted
+  // endpoints unchanged, but always try the current Cloud app API path first.
+  if (url.hostname === 'cloud.umami.is') {
+    candidates.unshift(`${url.origin}/analytics/us`);
   }
 
-  const url = new URL(baseUrl);
+  return [...new Set(candidates)];
+}
+
+function createApiUrl(apiBaseUrl: string, path: string): URL {
+  const url = new URL(apiBaseUrl);
   const basePath = url.pathname.replace(/\/$/, '');
-  url.pathname = `${basePath}/api/share/${encodeURIComponent(shareSlug)}`;
+  url.pathname = `${basePath}${path}`;
+  return url;
+}
+
+function isJsonResponse(response: Response): boolean {
+  return response.headers.get('content-type')?.includes('application/json') ?? false;
+}
+
+async function fetchShareData(apiBaseUrl: string, shareSlug: string): Promise<UmamiShareData | null> {
+  const url = createApiUrl(apiBaseUrl, `/api/share/${encodeURIComponent(shareSlug)}`);
 
   const response = await fetch(url.toString(), {
     method: 'GET',
     headers: { accept: 'application/json' },
   });
 
+  if (response.status === 404) return null;
   if (!response.ok) {
-    throw new Error(`Failed to resolve share token: ${response.status} ${response.statusText}`);
+    throw new Error(`Failed to resolve Umami share token: ${response.status} ${response.statusText}`);
+  }
+  if (!isJsonResponse(response)) {
+    throw new Error(`Unexpected Umami share response content type: ${response.headers.get('content-type') ?? 'unknown'}`);
   }
 
-  const data: { token: string; websiteId: string } = await response.json();
-  jwtCache = { token: data.token, expiresAt: Date.now() + JWT_CACHE_TTL, key };
-  return data.token;
+  const data: { token?: string; websiteId?: string } = await response.json();
+  if (!data.token) throw new Error('Umami share response did not include a token');
+
+  return {
+    token: data.token,
+    websiteId: data.websiteId,
+    apiBaseUrl,
+  };
+}
+
+/** Exchange a share slug for short-lived share metadata via GET /api/share/<slug>. */
+async function resolveShareData(baseUrl: string, shareSlug: string): Promise<UmamiShareData> {
+  const key = `${baseUrl}:${shareSlug}`;
+  if (shareDataCache && shareDataCache.key === key && shareDataCache.expiresAt > Date.now()) {
+    return shareDataCache.value;
+  }
+
+  for (const apiBaseUrl of getApiBaseUrlCandidates(baseUrl)) {
+    const shareData = await fetchShareData(apiBaseUrl, shareSlug);
+    if (!shareData) continue;
+
+    shareDataCache = { value: shareData, expiresAt: Date.now() + SHARE_DATA_CACHE_TTL, key };
+    return shareData;
+  }
+
+  throw new Error('Failed to resolve Umami share token: no compatible share API endpoint responded');
+}
+
+function getWebsiteId(configuredWebsiteId: string, shareData: UmamiShareData): string {
+  if (!shareData.websiteId) return configuredWebsiteId;
+
+  if (shareData.websiteId !== configuredWebsiteId && import.meta.env.DEV) {
+    console.warn(
+      `[umami-stats] Configured website ID "${configuredWebsiteId}" differs from the website ID in the Umami share link "${shareData.websiteId}". Using the share-link website ID for stats requests.`,
+    );
+  }
+
+  return shareData.websiteId;
 }
 
 async function getSessionStats(config: UmamiStatsConfig): Promise<UmamiSessionStats> {
-  const { baseUrl, websiteId, shareToken: shareSlug, path } = config;
+  const { baseUrl, websiteId: configuredWebsiteId, shareToken: shareSlug, path } = config;
 
-  const jwt = await resolveShareToken(baseUrl, shareSlug);
-
-  const url = new URL(baseUrl);
-  const basePath = url.pathname.replace(/\/$/, '');
-  url.pathname = `${basePath}/api/websites/${encodeURIComponent(websiteId)}/stats`;
+  const shareData = await resolveShareData(baseUrl, shareSlug);
+  const websiteId = getWebsiteId(configuredWebsiteId, shareData);
+  const url = createApiUrl(shareData.apiBaseUrl, `/api/websites/${encodeURIComponent(websiteId)}/stats`);
 
   const headers = new Headers({
     accept: 'application/json',
-    'x-umami-share-token': jwt,
+    'x-umami-share-token': shareData.token,
+    // Required by current Umami auth when a share token is used from the public share flow.
+    'x-umami-share-context': '1',
   });
 
   const params = new URLSearchParams();
@@ -70,7 +134,9 @@ const cache = new Map<string, CacheEntry>();
 const inflightRequests = new Map<string, Promise<number | null>>();
 
 function getCacheKey(config: UmamiStatsConfig): string {
-  return `${config.baseUrl}:${config.websiteId}:${config.path ?? ''}`;
+  return [config.baseUrl, config.websiteId, config.shareToken, config.path ?? '', config.startAt ?? 0, config.endAt ?? ''].join(
+    ':',
+  );
 }
 
 export function getPageviews(config: UmamiStatsConfig): Promise<number | null> {


### PR DESCRIPTION
## 概要

修复 Umami Cloud 分享统计 API 变更导致的访问量统计失效问题，另含日语文案修正与文档更新。

## 主要变更

### fix: 适配 Umami Cloud 新版分享统计 API (#186)

Umami Cloud 服务端升级到 v3 后，公开分享页的统计接口行为发生了变化（自托管 v2 实例不受影响），导致使用 Cloud 分享链接的站点前台访问量获取失败。本 PR 做了以下适配：

- **API 路径**：Cloud 的分享 API 现位于 `https://cloud.umami.is/analytics/us` 下（统计脚本仍在 `cloud.umami.is/script.js`）。域名指向 `cloud.umami.is` 时优先尝试该路径，404 时回退原路径，自托管实例行为不变。
- **新增请求头 `x-umami-share-context: 1`**：v3 要求纯 share token 的统计请求必须携带该头，否则返回 401。已收到主题用户独立反馈同一 401 问题，并以同样方式修复确认。
- **websiteId 以分享接口返回为准**：`/api/share/<slug>` 响应中的 `websiteId` 与 `site.yaml` 配置不一致时以前者为准，并在开发环境输出警告。
- **share 响应增加 content-type 校验**，避免把 HTML 错误页当 JSON 解析。
- **修复缓存键冲突**：缓存键补充 `shareToken`、`startAt`、`endAt`，避免更换 token 或不同时间范围的查询命中旧缓存。

### fix: 日语文案修正 (#187)

- `stats.pageviews`：アクセス数 → ページビュー（更准确的术语）
- 加密区块的占位/按钮文案精简（ロックを解除 → 解除）

### docs

- 修正「使用本主题」列表中 Ksable 的仓库地址（→ God-2077/astro-blog），三语 README 同步
- 新增 AGENTS.md 仓库开发指南

## 验证

- `pnpm exec biome check src/lib/umami-stats.ts` 通过
- `pnpm build` 通过
- 已针对 Umami Cloud 分享页做线上实测，前台访问量展示恢复正常

## 影响面

- 仅 `src/lib/umami-stats.ts` 涉及运行时行为变更；自托管 Umami v2 用户的请求路径与之前保持一致
- 无配置迁移成本，`site.yaml` 无需改动