### PR TITLE
feat: add settings center and reading preferences

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,6 +29,7 @@ import { remarkIns, remarkMark } from './src/lib/markdown/remark-shoka-effects.t
 import { remarkShokaPreprocess } from './src/lib/markdown/remark-shoka-preprocess.ts';
 import { remarkShokaRuby } from './src/lib/markdown/remark-shoka-ruby.ts';
 import { remarkShokaSpoiler } from './src/lib/markdown/remark-shoka-spoiler.ts';
+import { collapsibleCodeTransformer } from './src/lib/markdown/shiki-collapsible-transformer.ts';
 import { shokaMetaTransformer } from './src/lib/markdown/shiki-meta-transformer.ts';
 import { normalizeUrl } from './src/lib/utils.ts';
 
@@ -168,6 +169,7 @@ if (contentConfig.enableEncryptedBlock) {
 // Shiki transformers
 const shikiTransformers = [];
 if (contentConfig.enableCodeMeta !== false) shikiTransformers.push(shokaMetaTransformer());
+if (contentConfig.enhanceCodeBlock !== false) shikiTransformers.push(collapsibleCodeTransformer());
 
 // https://astro.build/config
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.3.3",
     "@react-three/fiber": "^9.4.2",
     "@tailwindcss/vite": "^4.1.17",
     "@types/react": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-switch':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@react-three/fiber':
         specifier: ^9.4.2
         version: 9.4.2(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(three@0.182.0)
@@ -2186,6 +2189,9 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.5':
+    resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
+
   '@radix-ui/react-alert-dialog@1.1.15':
     resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
     peerDependencies:
@@ -2247,6 +2253,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -2258,6 +2273,15 @@ packages:
 
   '@radix-ui/react-context@1.1.3':
     resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.0':
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2448,6 +2472,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.7':
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -2490,6 +2527,28 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.3.3':
+    resolution: {integrity: sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tabs@1.1.13':
@@ -2549,8 +2608,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2585,8 +2662,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-previous@1.1.1':
     resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2605,6 +2700,15 @@ packages:
 
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -11401,6 +11505,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/primitive@1.1.5': {}
+
   '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -11455,6 +11561,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.7)(react@19.2.1)':
     dependencies:
       react: 19.2.1
@@ -11462,6 +11574,12 @@ snapshots:
       '@types/react': 19.2.7
 
   '@radix-ui/react-context@1.1.3(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-context@1.2.0(@types/react@19.2.7)(react@19.2.1)':
     dependencies:
       react: 19.2.1
     optionalDependencies:
@@ -11661,6 +11779,15 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -11720,6 +11847,28 @@ snapshots:
       react: 19.2.1
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-switch@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -11782,9 +11931,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.7)(react@19.2.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       react: 19.2.1
     optionalDependencies:
       '@types/react': 19.2.7
@@ -11809,7 +11973,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@19.2.7)(react@19.2.1)':
     dependencies:
       react: 19.2.1
     optionalDependencies:
@@ -11825,6 +12001,13 @@ snapshots:
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.7)(react@19.2.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.1)
+      react: 19.2.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.7)(react@19.2.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       react: 19.2.1
     optionalDependencies:
       '@types/react': 19.2.7

--- a/src/components/layout/FloatingGroup.tsx
+++ b/src/components/layout/FloatingGroup.tsx
@@ -15,7 +15,8 @@ import { cn } from '@lib/utils';
 import { useStore } from '@nanostores/react';
 import { $bgmPanelOpen, toggleBgmPanel } from '@store/bgm';
 import { christmasEnabled, disableChristmasCompletely, enableChristmas, initChristmasState } from '@store/christmas';
-import { $isDrawerOpen } from '@store/modal';
+import { $isDrawerOpen, $isSettingsOpen, toggleSettings } from '@store/modal';
+import { bgmWidgetEnabled, initSettings } from '@store/settings';
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useState } from 'react';
 
@@ -27,9 +28,19 @@ interface FloatingButtonProps {
   className?: string;
   /** Optional data attribute for identifying BGM toggle button */
   dataBgmToggle?: boolean;
+  /** Optional data attribute for identifying settings toggle button */
+  dataSettingsToggle?: boolean;
 }
 
-function FloatingButton({ onClick, ariaLabel, title, children, className, dataBgmToggle }: FloatingButtonProps) {
+function FloatingButton({
+  onClick,
+  ariaLabel,
+  title,
+  children,
+  className,
+  dataBgmToggle,
+  dataSettingsToggle,
+}: FloatingButtonProps) {
   const isMounted = useIsMounted();
 
   return (
@@ -43,6 +54,7 @@ function FloatingButton({ onClick, ariaLabel, title, children, className, dataBg
       aria-label={ariaLabel}
       title={isMounted ? title : undefined}
       data-bgm-toggle={dataBgmToggle || undefined}
+      data-settings-toggle={dataSettingsToggle || undefined}
     >
       {children}
     </button>
@@ -55,10 +67,13 @@ export default function FloatingGroup() {
   const isDrawerOpen = useStore($isDrawerOpen);
   const isChristmasEnabled = useStore(christmasEnabled);
   const isBgmPanelOpen = useStore($bgmPanelOpen);
+  const isSettingsOpen = useStore($isSettingsOpen);
+  const isBgmWidgetEnabled = useStore(bgmWidgetEnabled);
 
-  // Initialize christmas state on mount
+  // Initialize christmas & settings state on mount
   useEffect(() => {
     initChristmasState();
+    initSettings();
   }, []);
 
   const scrollToTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -102,11 +117,19 @@ export default function FloatingGroup() {
                 <Icon icon={isChristmasEnabled ? 'ri:snowy-fill' : 'ri:snowy-line'} className="h-5 w-5" />
               </FloatingButton>
             )}
-            {bgmConfig.enabled && bgmConfig.audio.length > 0 && (
+            {bgmConfig.enabled && bgmConfig.audio.length > 0 && isBgmWidgetEnabled && (
               <FloatingButton onClick={toggleBgmPanel} ariaLabel={t('floating.bgm')} title={t('floating.bgm')} dataBgmToggle>
                 <Icon icon={isBgmPanelOpen ? 'ri:music-2-fill' : 'ri:music-2-line'} className="h-5 w-5" />
               </FloatingButton>
             )}
+            <FloatingButton
+              onClick={toggleSettings}
+              ariaLabel={t('floating.settings')}
+              title={t('floating.settings')}
+              dataSettingsToggle
+            >
+              <Icon icon={isSettingsOpen ? 'ri:settings-3-fill' : 'ri:settings-3-line'} className="h-5 w-5" />
+            </FloatingButton>
             <FloatingButton onClick={scrollToTop} ariaLabel={t('floating.backToTop')} title={t('floating.backToTop')}>
               <Icon icon="ri:arrow-up-s-line" className="h-5 w-5" />
             </FloatingButton>

--- a/src/components/layout/MobilePostHeader/ProgressCircle.tsx
+++ b/src/components/layout/MobilePostHeader/ProgressCircle.tsx
@@ -5,6 +5,8 @@
  * Uses Motion's useScroll for tracking and useSpring for smooth animation.
  */
 
+import { useStore } from '@nanostores/react';
+import { masterMotionEnabled, scrollProgressEnabled } from '@store/settings';
 import { motion, useReducedMotion, useScroll, useSpring } from 'motion/react';
 
 interface ProgressCircleProps {
@@ -18,6 +20,8 @@ interface ProgressCircleProps {
 
 export function ProgressCircle({ size = 28, strokeWidth = 2, className }: ProgressCircleProps) {
   const shouldReduceMotion = useReducedMotion();
+  const enabled = useStore(scrollProgressEnabled);
+  const masterMotion = useStore(masterMotionEnabled);
   const { scrollYProgress } = useScroll();
 
   const springProgress = useSpring(scrollYProgress, {
@@ -26,8 +30,9 @@ export function ProgressCircle({ size = 28, strokeWidth = 2, className }: Progre
     restDelta: 0.001,
   });
 
-  // Apply spring smoothing unless user prefers reduced motion
-  const progress = shouldReduceMotion ? scrollYProgress : springProgress;
+  const progress = shouldReduceMotion || masterMotion ? scrollYProgress : springProgress;
+
+  if (!enabled) return null;
 
   const radius = (size - strokeWidth) / 2;
   const center = size / 2;

--- a/src/components/layout/ScrollProgress.tsx
+++ b/src/components/layout/ScrollProgress.tsx
@@ -1,3 +1,5 @@
+import { useStore } from '@nanostores/react';
+import { masterMotionEnabled, scrollProgressEnabled } from '@store/settings';
 import { motion, useReducedMotion, useScroll, useSpring } from 'motion/react';
 
 interface ScrollProgressProps {
@@ -6,6 +8,9 @@ interface ScrollProgressProps {
 
 export function ScrollProgress({ className }: ScrollProgressProps) {
   const shouldReduceMotion = useReducedMotion();
+  // Keep the progress indicator static when either reduced-motion preference is active.
+  const enabled = useStore(scrollProgressEnabled);
+  const masterMotion = useStore(masterMotionEnabled);
 
   // 监听页面滚动进度
   const { scrollYProgress } = useScroll();
@@ -18,7 +23,9 @@ export function ScrollProgress({ className }: ScrollProgressProps) {
   });
 
   // 如果用户偏好减少动画，则直接使用滚动进度值，不使用 spring
-  const scaleX = shouldReduceMotion ? scrollYProgress : springProgress;
+  const scaleX = shouldReduceMotion || masterMotion ? scrollYProgress : springProgress;
+
+  if (!enabled) return null;
 
   return (
     <div className={className}>

--- a/src/components/markdown/CodeBlockToolbar.tsx
+++ b/src/components/markdown/CodeBlockToolbar.tsx
@@ -5,7 +5,6 @@
 
 import { CopyButton } from '@components/markdown/shared/CopyButton';
 import { MacToolbar } from '@components/markdown/shared/MacToolbar';
-import { COLLAPSE_LINE_THRESHOLD } from '@constants/code-block';
 import { useTranslation } from '@hooks/useTranslation';
 import { Icon } from '@iconify/react';
 import { extractCode, extractCodeClassName, extractCodeHTML, extractLanguage } from '@lib/content-enhancer-utils';
@@ -36,7 +35,8 @@ export function CodeBlockToolbar({ preElement, enableCopy = true, enableFullscre
     [preElement],
   );
 
-  const collapsible = useMemo(() => info.code.replace(/\n$/, '').split('\n').length > COLLAPSE_LINE_THRESHOLD, [info.code]);
+  // The build-time transformer owns the collapsibility decision; the wrapper class is its output.
+  const collapsible = useMemo(() => preElement.parentElement?.classList.contains('code-collapsible') ?? false, [preElement]);
   const [collapsed, setCollapsed] = useState(collapsible);
 
   useLayoutEffect(() => {
@@ -50,8 +50,6 @@ export function CodeBlockToolbar({ preElement, enableCopy = true, enableFullscre
   useEffect(() => {
     const wrapper = preElement.parentElement;
     if (!wrapper || !collapsible) return;
-    wrapper.classList.add('code-collapsible');
-
     const toolbar = wrapper.querySelector('.code-block-wrapper-toolbar-mount');
     const handleBarClick = (event: Event) => {
       // Buttons and title links keep their own behavior instead of toggling the block.
@@ -59,10 +57,7 @@ export function CodeBlockToolbar({ preElement, enableCopy = true, enableFullscre
       setCollapsed((prev) => !prev);
     };
     toolbar?.addEventListener('click', handleBarClick);
-    return () => {
-      wrapper.classList.remove('code-collapsible');
-      toolbar?.removeEventListener('click', handleBarClick);
-    };
+    return () => toolbar?.removeEventListener('click', handleBarClick);
   }, [preElement, collapsible]);
 
   const handleFullscreen = () => {

--- a/src/components/markdown/CodeBlockToolbar.tsx
+++ b/src/components/markdown/CodeBlockToolbar.tsx
@@ -5,15 +5,13 @@
 
 import { CopyButton } from '@components/markdown/shared/CopyButton';
 import { MacToolbar } from '@components/markdown/shared/MacToolbar';
+import { COLLAPSE_LINE_THRESHOLD } from '@constants/code-block';
 import { useTranslation } from '@hooks/useTranslation';
 import { Icon } from '@iconify/react';
 import { extractCode, extractCodeClassName, extractCodeHTML, extractLanguage } from '@lib/content-enhancer-utils';
 import { cn } from '@lib/utils';
 import { openModal } from '@store/modal';
-import { useEffect, useMemo, useRef, useState } from 'react';
-
-/** Code blocks longer than this threshold start collapsed. */
-const COLLAPSE_LINE_THRESHOLD = 8;
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 
 interface CodeBlockToolbarProps {
   preElement: HTMLElement;
@@ -40,24 +38,19 @@ export function CodeBlockToolbar({ preElement, enableCopy = true, enableFullscre
 
   const collapsible = useMemo(() => info.code.replace(/\n$/, '').split('\n').length > COLLAPSE_LINE_THRESHOLD, [info.code]);
   const [collapsed, setCollapsed] = useState(collapsible);
-  const isFirstRender = useRef(true);
 
-  // Mirror the collapsed state on the wrapper and make the toolbar clickable.
+  useLayoutEffect(() => {
+    const wrapper = preElement.parentElement;
+    if (!wrapper || !collapsible) return;
+    wrapper.classList.toggle('code-collapsed', collapsed);
+    return () => wrapper.classList.remove('code-collapsed');
+  }, [preElement, collapsible, collapsed]);
+
+  // Make the full toolbar clickable while preserving button and link behavior.
   useEffect(() => {
     const wrapper = preElement.parentElement;
     if (!wrapper || !collapsible) return;
     wrapper.classList.add('code-collapsible');
-
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      // Skip the initial animation to avoid layout shifts when many long blocks mount together.
-      if (collapsed) {
-        wrapper.classList.add('code-collapsed', 'code-no-transition');
-        requestAnimationFrame(() => wrapper.classList.remove('code-no-transition'));
-      }
-    } else {
-      wrapper.classList.toggle('code-collapsed', collapsed);
-    }
 
     const toolbar = wrapper.querySelector('.code-block-wrapper-toolbar-mount');
     const handleBarClick = (event: Event) => {
@@ -67,10 +60,10 @@ export function CodeBlockToolbar({ preElement, enableCopy = true, enableFullscre
     };
     toolbar?.addEventListener('click', handleBarClick);
     return () => {
-      wrapper.classList.remove('code-collapsed', 'code-collapsible');
+      wrapper.classList.remove('code-collapsible');
       toolbar?.removeEventListener('click', handleBarClick);
     };
-  }, [preElement, collapsible, collapsed]);
+  }, [preElement, collapsible]);
 
   const handleFullscreen = () => {
     openModal('codeFullscreen', info);

--- a/src/components/markdown/CodeBlockToolbar.tsx
+++ b/src/components/markdown/CodeBlockToolbar.tsx
@@ -8,8 +8,12 @@ import { MacToolbar } from '@components/markdown/shared/MacToolbar';
 import { useTranslation } from '@hooks/useTranslation';
 import { Icon } from '@iconify/react';
 import { extractCode, extractCodeClassName, extractCodeHTML, extractLanguage } from '@lib/content-enhancer-utils';
+import { cn } from '@lib/utils';
 import { openModal } from '@store/modal';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+/** Code blocks longer than this threshold start collapsed. */
+const COLLAPSE_LINE_THRESHOLD = 8;
 
 interface CodeBlockToolbarProps {
   preElement: HTMLElement;
@@ -34,6 +38,40 @@ export function CodeBlockToolbar({ preElement, enableCopy = true, enableFullscre
     [preElement],
   );
 
+  const collapsible = useMemo(() => info.code.replace(/\n$/, '').split('\n').length > COLLAPSE_LINE_THRESHOLD, [info.code]);
+  const [collapsed, setCollapsed] = useState(collapsible);
+  const isFirstRender = useRef(true);
+
+  // Mirror the collapsed state on the wrapper and make the toolbar clickable.
+  useEffect(() => {
+    const wrapper = preElement.parentElement;
+    if (!wrapper || !collapsible) return;
+    wrapper.classList.add('code-collapsible');
+
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      // Skip the initial animation to avoid layout shifts when many long blocks mount together.
+      if (collapsed) {
+        wrapper.classList.add('code-collapsed', 'code-no-transition');
+        requestAnimationFrame(() => wrapper.classList.remove('code-no-transition'));
+      }
+    } else {
+      wrapper.classList.toggle('code-collapsed', collapsed);
+    }
+
+    const toolbar = wrapper.querySelector('.code-block-wrapper-toolbar-mount');
+    const handleBarClick = (event: Event) => {
+      // Buttons and title links keep their own behavior instead of toggling the block.
+      if ((event.target as HTMLElement).closest('button, a')) return;
+      setCollapsed((prev) => !prev);
+    };
+    toolbar?.addEventListener('click', handleBarClick);
+    return () => {
+      wrapper.classList.remove('code-collapsed', 'code-collapsible');
+      toolbar?.removeEventListener('click', handleBarClick);
+    };
+  }, [preElement, collapsible, collapsed]);
+
   const handleFullscreen = () => {
     openModal('codeFullscreen', info);
   };
@@ -46,6 +84,21 @@ export function CodeBlockToolbar({ preElement, enableCopy = true, enableFullscre
       linkText={info.linkText}
       onFullscreen={enableFullscreen ? handleFullscreen : undefined}
     >
+      {collapsible && (
+        <button
+          type="button"
+          onClick={() => setCollapsed((prev) => !prev)}
+          className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground active:scale-95"
+          aria-label={collapsed ? t('code.expand') : t('code.collapse')}
+          aria-expanded={!collapsed}
+          title={collapsed ? t('code.expand') : t('code.collapse')}
+        >
+          <Icon
+            icon="ri:arrow-down-s-line"
+            className={cn('size-4 transition-transform duration-200', !collapsed && 'rotate-180')}
+          />
+        </button>
+      )}
       {enableFullscreen && (
         <button
           type="button"

--- a/src/components/settings/NumberField.tsx
+++ b/src/components/settings/NumberField.tsx
@@ -107,7 +107,7 @@ export function NumberField({ label, value, step, unit, emptyValue, onApply }: N
     <div className="flex items-center gap-1" title={invalid ? t('settings.invalidNumber') : undefined}>
       <button
         type="button"
-        className="size-7 flex-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        className="size-7 flex-center rounded-md text-muted-foreground transition-[background-color,color,transform] hover:bg-accent hover:text-foreground active:scale-[0.96]"
         onClick={() => stepBy(-1)}
         aria-label={`${label} -${step}`}
       >
@@ -121,7 +121,7 @@ export function NumberField({ label, value, step, unit, emptyValue, onApply }: N
           aria-label={label}
           aria-invalid={invalid || undefined}
           className={cn(
-            'w-20 rounded-md border border-input bg-background px-2 py-1 text-center text-sm outline-hidden transition-colors',
+            'w-20 rounded-md border border-input bg-background px-2 py-1 text-center text-sm tabular-nums outline-hidden transition-colors',
             'focus-visible:ring-2 focus-visible:ring-ring',
             invalid && 'border-destructive text-destructive focus-visible:ring-destructive',
           )}
@@ -137,7 +137,7 @@ export function NumberField({ label, value, step, unit, emptyValue, onApply }: N
       </div>
       <button
         type="button"
-        className="size-7 flex-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        className="size-7 flex-center rounded-md text-muted-foreground transition-[background-color,color,transform] hover:bg-accent hover:text-foreground active:scale-[0.96]"
         onClick={() => stepBy(1)}
         aria-label={`${label} +${step}`}
       >

--- a/src/components/settings/NumberField.tsx
+++ b/src/components/settings/NumberField.tsx
@@ -2,7 +2,7 @@
  * Numeric stepper used by the Settings Center.
  *
  * react-hook-form and Zod accept any finite positive number without an upper clamp.
- * Valid input applies after a short debounce; invalid input only shows an error state.
+ * Selected controls may also use an empty value for an automatic setting.
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -14,7 +14,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 const schema = z.object({
-  value: z.number().positive().finite(),
+  value: z.number().positive().finite().nullable(),
 });
 type FormValues = z.infer<typeof schema>;
 
@@ -23,10 +23,14 @@ const APPLY_DEBOUNCE = 150;
 
 interface NumberFieldProps {
   label: string;
-  value: number;
+  value: number | null;
   step: number;
   unit?: string;
-  onApply: (value: number) => void;
+  emptyValue?: {
+    label: string;
+    fallback: number;
+  };
+  onApply: (value: number | null) => void;
 }
 
 /** Remove floating-point noise from fractional steps. */
@@ -34,8 +38,9 @@ function round(value: number): number {
   return Number(value.toFixed(4));
 }
 
-export function NumberField({ label, value, step, unit, onApply }: NumberFieldProps) {
+export function NumberField({ label, value, step, unit, emptyValue, onApply }: NumberFieldProps) {
   const { t } = useTranslation();
+  const allowsEmpty = emptyValue !== undefined;
   const {
     register,
     watch,
@@ -48,7 +53,7 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
   });
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const applyWatchedValue = useEffectEvent((next: number) => {
+  const applyWatchedValue = useEffectEvent((next: number | null) => {
     if (next === value) return;
     debounceRef.current = setTimeout(() => onApply(next), APPLY_DEBOUNCE);
   });
@@ -70,6 +75,10 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
         clearTimeout(debounceRef.current);
         debounceRef.current = null;
       }
+      if (next === null) {
+        if (allowsEmpty) applyWatchedValue(null);
+        return;
+      }
       if (typeof next !== 'number' || !Number.isFinite(next) || next <= 0) return;
       applyWatchedValue(next);
     });
@@ -77,10 +86,12 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
       subscription.unsubscribe();
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [watch]);
+  }, [watch, allowsEmpty]);
 
   const stepBy = (direction: 1 | -1) => {
-    const next = round(value + direction * step);
+    const base = value ?? emptyValue?.fallback;
+    if (base === undefined) return;
+    const next = round(base + direction * step);
     if (next <= 0) return;
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
@@ -89,7 +100,8 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
     onApply(next);
   };
 
-  const invalid = Boolean(errors.value);
+  const inputValue = watch('value');
+  const invalid = Boolean(errors.value) || (inputValue === null && !allowsEmpty);
 
   return (
     <div className="flex items-center gap-1" title={invalid ? t('settings.invalidNumber') : undefined}>
@@ -105,6 +117,7 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
         <input
           type="number"
           step={step}
+          placeholder={emptyValue?.label}
           aria-label={label}
           aria-invalid={invalid || undefined}
           className={cn(
@@ -112,9 +125,11 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
             'focus-visible:ring-2 focus-visible:ring-ring',
             invalid && 'border-destructive text-destructive focus-visible:ring-destructive',
           )}
-          {...register('value', { valueAsNumber: true })}
+          {...register('value', {
+            setValueAs: (rawValue) => (rawValue === '' ? null : Number(rawValue)),
+          })}
         />
-        {unit && (
+        {unit && inputValue !== null && (
           <span className="pointer-events-none absolute top-1/2 right-1.5 -translate-y-1/2 text-muted-foreground text-xs">
             {unit}
           </span>

--- a/src/components/settings/NumberField.tsx
+++ b/src/components/settings/NumberField.tsx
@@ -9,7 +9,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from '@hooks/useTranslation';
 import { Icon } from '@iconify/react';
 import { cn } from '@lib/utils';
-import { useEffect, useRef } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -48,8 +48,10 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
   });
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const valueRef = useRef(value);
-  valueRef.current = value;
+  const applyWatchedValue = useEffectEvent((next: number) => {
+    if (next === value) return;
+    debounceRef.current = setTimeout(() => onApply(next), APPLY_DEBOUNCE);
+  });
 
   // Synchronize external changes from the stepper or reset action.
   useEffect(() => {
@@ -69,17 +71,16 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
         debounceRef.current = null;
       }
       if (typeof next !== 'number' || !Number.isFinite(next) || next <= 0) return;
-      if (next === valueRef.current) return;
-      debounceRef.current = setTimeout(() => onApply(next), APPLY_DEBOUNCE);
+      applyWatchedValue(next);
     });
     return () => {
       subscription.unsubscribe();
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [watch, onApply]);
+  }, [watch]);
 
   const stepBy = (direction: 1 | -1) => {
-    const next = round(valueRef.current + direction * step);
+    const next = round(value + direction * step);
     if (next <= 0) return;
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);

--- a/src/components/settings/NumberField.tsx
+++ b/src/components/settings/NumberField.tsx
@@ -53,6 +53,10 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
 
   // Synchronize external changes from the stepper or reset action.
   useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
     setValue('value', value, { shouldValidate: true });
   }, [value, setValue]);
 
@@ -60,9 +64,12 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
   useEffect(() => {
     const subscription = watch((data) => {
       const next = data.value;
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
       if (typeof next !== 'number' || !Number.isFinite(next) || next <= 0) return;
       if (next === valueRef.current) return;
-      if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => onApply(next), APPLY_DEBOUNCE);
     });
     return () => {
@@ -74,6 +81,10 @@ export function NumberField({ label, value, step, unit, onApply }: NumberFieldPr
   const stepBy = (direction: 1 | -1) => {
     const next = round(valueRef.current + direction * step);
     if (next <= 0) return;
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
     onApply(next);
   };
 

--- a/src/components/settings/NumberField.tsx
+++ b/src/components/settings/NumberField.tsx
@@ -1,0 +1,121 @@
+/**
+ * Numeric stepper used by the Settings Center.
+ *
+ * react-hook-form and Zod accept any finite positive number without an upper clamp.
+ * Valid input applies after a short debounce; invalid input only shows an error state.
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from '@hooks/useTranslation';
+import { Icon } from '@iconify/react';
+import { cn } from '@lib/utils';
+import { useEffect, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const schema = z.object({
+  value: z.number().positive().finite(),
+});
+type FormValues = z.infer<typeof schema>;
+
+/** Input debounce interval in milliseconds. */
+const APPLY_DEBOUNCE = 150;
+
+interface NumberFieldProps {
+  label: string;
+  value: number;
+  step: number;
+  unit?: string;
+  onApply: (value: number) => void;
+}
+
+/** Remove floating-point noise from fractional steps. */
+function round(value: number): number {
+  return Number(value.toFixed(4));
+}
+
+export function NumberField({ label, value, step, unit, onApply }: NumberFieldProps) {
+  const { t } = useTranslation();
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { value },
+    mode: 'onChange',
+  });
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  // Synchronize external changes from the stepper or reset action.
+  useEffect(() => {
+    setValue('value', value, { shouldValidate: true });
+  }, [value, setValue]);
+
+  // Apply valid input after the debounce; validation owns the error state.
+  useEffect(() => {
+    const subscription = watch((data) => {
+      const next = data.value;
+      if (typeof next !== 'number' || !Number.isFinite(next) || next <= 0) return;
+      if (next === valueRef.current) return;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => onApply(next), APPLY_DEBOUNCE);
+    });
+    return () => {
+      subscription.unsubscribe();
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [watch, onApply]);
+
+  const stepBy = (direction: 1 | -1) => {
+    const next = round(valueRef.current + direction * step);
+    if (next <= 0) return;
+    onApply(next);
+  };
+
+  const invalid = Boolean(errors.value);
+
+  return (
+    <div className="flex items-center gap-1" title={invalid ? t('settings.invalidNumber') : undefined}>
+      <button
+        type="button"
+        className="size-7 flex-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        onClick={() => stepBy(-1)}
+        aria-label={`${label} -${step}`}
+      >
+        <Icon icon="ri:subtract-line" className="h-4 w-4" />
+      </button>
+      <div className="relative">
+        <input
+          type="number"
+          step={step}
+          aria-label={label}
+          aria-invalid={invalid || undefined}
+          className={cn(
+            'w-20 rounded-md border border-input bg-background px-2 py-1 text-center text-sm outline-hidden transition-colors',
+            'focus-visible:ring-2 focus-visible:ring-ring',
+            invalid && 'border-destructive text-destructive focus-visible:ring-destructive',
+          )}
+          {...register('value', { valueAsNumber: true })}
+        />
+        {unit && (
+          <span className="pointer-events-none absolute top-1/2 right-1.5 -translate-y-1/2 text-muted-foreground text-xs">
+            {unit}
+          </span>
+        )}
+      </div>
+      <button
+        type="button"
+        className="size-7 flex-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        onClick={() => stepBy(1)}
+        aria-label={`${label} +${step}`}
+      >
+        <Icon icon="ri:add-line" className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,0 +1,245 @@
+/**
+ * Settings Center popover.
+ *
+ * This is the single container for reader and general preferences; see CONTEXT.md.
+ * Controls render from the declarative registry and the modal store owns visibility.
+ */
+
+import { Switch } from '@components/ui/switch';
+import { microReboundPreset } from '@constants/anim/spring';
+import { FloatingFocusManager, useDismiss, useFloating, useInteractions, useRole } from '@floating-ui/react';
+import { useTranslation } from '@hooks/useTranslation';
+import { Icon } from '@iconify/react';
+import { cn } from '@lib/utils';
+import { useStore } from '@nanostores/react';
+import { christmasEnabled, toggleChristmas } from '@store/christmas';
+import { $isSettingsOpen, closeModal } from '@store/modal';
+import {
+  bgmWidgetEnabled,
+  type FontPreset,
+  initSettings,
+  masterMotionEnabled,
+  readerFontPreset,
+  readerFontSize,
+  readerJustify,
+  readerLineHeight,
+  readerMeasure,
+  resetReaderPreferences,
+  scrollProgressEnabled,
+  setBgmWidgetEnabled,
+  setFontPreset,
+  setFontSize,
+  setJustify,
+  setLineHeight,
+  setMasterMotionEnabled,
+  setMeasure,
+  setScrollProgressEnabled,
+  setWaveEnabled,
+  waveEnabled,
+} from '@store/settings';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import { useEffect, useState } from 'react';
+import { NumberField } from './NumberField';
+import { isSettingVisible, SETTINGS_REGISTRY, type SettingItem, type SettingSection } from './registry';
+
+const SECTIONS: SettingSection[] = ['reader', 'general'];
+
+export default function SettingsPanel() {
+  const { t } = useTranslation();
+  const open = useStore($isSettingsOpen);
+  const shouldReduceMotion = useReducedMotion();
+
+  // Store bindings
+  const fontPreset = useStore(readerFontPreset);
+  const fontSize = useStore(readerFontSize);
+  const lineHeight = useStore(readerLineHeight);
+  const measure = useStore(readerMeasure);
+  const justify = useStore(readerJustify);
+  const scrollProgress = useStore(scrollProgressEnabled);
+  const bgmWidget = useStore(bgmWidgetEnabled);
+  const masterMotion = useStore(masterMotionEnabled);
+  const wave = useStore(waveEnabled);
+  const isChristmasEnabled = useStore(christmasEnabled);
+
+  const switchBindings: Record<string, { checked: boolean; onChange: (checked: boolean) => void }> = {
+    justify: { checked: justify, onChange: setJustify },
+    scrollProgress: { checked: scrollProgress, onChange: setScrollProgressEnabled },
+    christmas: { checked: isChristmasEnabled, onChange: () => toggleChristmas() },
+    bgmWidget: { checked: bgmWidget, onChange: setBgmWidgetEnabled },
+    masterMotion: { checked: masterMotion, onChange: setMasterMotionEnabled },
+    wave: { checked: wave, onChange: setWaveEnabled },
+  };
+
+  const numberBindings: Record<string, { value: number; onApply: (value: number) => void }> = {
+    fontSize: { value: fontSize, onApply: setFontSize },
+    lineHeight: { value: lineHeight, onApply: setLineHeight },
+    measure: { value: measure, onApply: setMeasure },
+  };
+
+  // Open on Reading for article pages and General everywhere else.
+  const [section, setSection] = useState<SettingSection>('general');
+  useEffect(() => {
+    if (!open) return;
+    setSection(document.querySelector('article[data-pagefind-body]') ? 'reader' : 'general');
+  }, [open]);
+
+  // Initialize settings from localStorage on mount
+  useEffect(() => {
+    initSettings();
+  }, []);
+
+  // floating-ui: dismiss on ESC / outside click
+  const { refs, context } = useFloating({
+    open,
+    onOpenChange: (next) => {
+      if (!next) closeModal();
+    },
+  });
+  const dismiss = useDismiss(context, {
+    outsidePressEvent: 'mousedown',
+    // Exclude the settings toggle button in FloatingGroup to prevent toggle/dismiss race
+    outsidePress: (event) => {
+      const target = event.target as HTMLElement;
+      return !target.closest('[data-settings-toggle]');
+    },
+  });
+  const role = useRole(context, { role: 'dialog' });
+  const { getFloatingProps } = useInteractions([dismiss, role]);
+
+  const renderControl = (item: SettingItem) => {
+    const disabled = Boolean(item.disabledByMasterMotion && masterMotion);
+
+    switch (item.type) {
+      case 'segmented':
+        return (
+          <div className="flex flex-wrap gap-1">
+            {item.options?.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setFontPreset(option.value as FontPreset)}
+                aria-pressed={fontPreset === option.value}
+                className={cn(
+                  'rounded-md px-2.5 py-1 text-xs transition-colors',
+                  fontPreset === option.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:bg-accent hover:text-foreground',
+                )}
+              >
+                {t(option.i18nKey)}
+              </button>
+            ))}
+          </div>
+        );
+      case 'number': {
+        const binding = numberBindings[item.key];
+        if (!binding) return null;
+        return (
+          <NumberField
+            label={t(item.i18nKey)}
+            value={binding.value}
+            step={item.step ?? 1}
+            unit={item.unit}
+            onApply={binding.onApply}
+          />
+        );
+      }
+      case 'switch': {
+        const binding = switchBindings[item.key];
+        if (!binding) return null;
+        return (
+          <Switch
+            checked={binding.checked}
+            onCheckedChange={binding.onChange}
+            disabled={disabled}
+            aria-label={t(item.i18nKey)}
+          />
+        );
+      }
+    }
+  };
+
+  const items = SETTINGS_REGISTRY.filter((item) => item.section === section && isSettingVisible(item));
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <FloatingFocusManager context={context} modal={false}>
+          <motion.div
+            ref={refs.setFloating}
+            {...getFloatingProps()}
+            className="fixed right-16 bottom-20 z-40 w-[320px] max-w-[calc(100vw-5rem)]"
+            initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.95 }}
+            transition={shouldReduceMotion ? { duration: 0.15 } : microReboundPreset}
+          >
+            <div className="rounded-2xl border border-border bg-popover p-4 text-popover-foreground shadow-xl">
+              {/* Header */}
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="font-semibold text-sm">{t('settings.title')}</h2>
+                <button
+                  type="button"
+                  className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  onClick={closeModal}
+                  aria-label={t('settings.closePanel')}
+                >
+                  <Icon icon="ri:close-line" className="h-4 w-4" />
+                </button>
+              </div>
+
+              {/* Section tabs */}
+              <div className="mb-3 flex gap-1 rounded-lg bg-muted p-1">
+                {SECTIONS.map((key) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setSection(key)}
+                    className={cn(
+                      'flex-1 rounded-md px-3 py-1 font-medium text-xs transition-colors',
+                      section === key
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    {t(key === 'reader' ? 'settings.reader' : 'settings.general')}
+                  </button>
+                ))}
+              </div>
+
+              {/* Setting items */}
+              <div className="flex flex-col divide-y divide-border">
+                {items.map((item) => {
+                  const disabled = Boolean(item.disabledByMasterMotion && masterMotion);
+                  return (
+                    <div key={item.key} className="py-2.5 first:pt-1 last:pb-1">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className={cn('text-sm', disabled && 'opacity-50')}>{t(item.i18nKey)}</span>
+                        {item.type !== 'segmented' && renderControl(item)}
+                      </div>
+                      {item.type === 'segmented' && <div className="mt-2">{renderControl(item)}</div>}
+                      {disabled && (
+                        <p className="mt-1 text-muted-foreground text-xs">{t('settings.waveDisabledByMasterMotion')}</p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Reader section: reset */}
+              {section === 'reader' && (
+                <button
+                  type="button"
+                  onClick={resetReaderPreferences}
+                  className="mt-3 w-full rounded-md border border-input py-1.5 text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground"
+                >
+                  {t('settings.reset')}
+                </button>
+              )}
+            </div>
+          </motion.div>
+        </FloatingFocusManager>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,245 +1,29 @@
 /**
- * Settings Center popover.
+ * Lazy-loading shell for the Settings Center.
  *
- * This is the single container for reader and general preferences; see CONTEXT.md.
- * Controls render from the declarative registry and the modal store owns visibility.
+ * Keeps floating-ui / react-hook-form / zod out of the first-paint bundle: the heavy body
+ * (SettingsPanelContent) is fetched only once the panel is first opened, then kept mounted so the
+ * AnimatePresence exit animation still runs on close.
  */
 
-import { Switch } from '@components/ui/switch';
-import { microReboundPreset } from '@constants/anim/spring';
-import { FloatingFocusManager, useDismiss, useFloating, useInteractions, useRole } from '@floating-ui/react';
-import { useTranslation } from '@hooks/useTranslation';
-import { Icon } from '@iconify/react';
-import { cn } from '@lib/utils';
 import { useStore } from '@nanostores/react';
-import { christmasEnabled, toggleChristmas } from '@store/christmas';
-import { $isSettingsOpen, closeModal } from '@store/modal';
-import {
-  bgmWidgetEnabled,
-  type FontPreset,
-  initSettings,
-  masterMotionEnabled,
-  readerFontPreset,
-  readerFontSize,
-  readerJustify,
-  readerLineHeight,
-  readerMeasure,
-  resetReaderPreferences,
-  scrollProgressEnabled,
-  setBgmWidgetEnabled,
-  setFontPreset,
-  setFontSize,
-  setJustify,
-  setLineHeight,
-  setMasterMotionEnabled,
-  setMeasure,
-  setScrollProgressEnabled,
-  setWaveEnabled,
-  waveEnabled,
-} from '@store/settings';
-import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
-import { useEffect, useState } from 'react';
-import { NumberField } from './NumberField';
-import { isSettingVisible, SETTINGS_REGISTRY, type SettingItem, type SettingSection } from './registry';
+import { $isSettingsOpen } from '@store/modal';
+import { lazy, Suspense, useEffect, useState } from 'react';
 
-const SECTIONS: SettingSection[] = ['reader', 'general'];
+const SettingsPanelContent = lazy(() => import('./SettingsPanelContent'));
 
 export default function SettingsPanel() {
-  const { t } = useTranslation();
   const open = useStore($isSettingsOpen);
-  const shouldReduceMotion = useReducedMotion();
+  const [loaded, setLoaded] = useState(false);
 
-  // Store bindings
-  const fontPreset = useStore(readerFontPreset);
-  const fontSize = useStore(readerFontSize);
-  const lineHeight = useStore(readerLineHeight);
-  const measure = useStore(readerMeasure);
-  const justify = useStore(readerJustify);
-  const scrollProgress = useStore(scrollProgressEnabled);
-  const bgmWidget = useStore(bgmWidgetEnabled);
-  const masterMotion = useStore(masterMotionEnabled);
-  const wave = useStore(waveEnabled);
-  const isChristmasEnabled = useStore(christmasEnabled);
-
-  const switchBindings: Record<string, { checked: boolean; onChange: (checked: boolean) => void }> = {
-    justify: { checked: justify, onChange: setJustify },
-    scrollProgress: { checked: scrollProgress, onChange: setScrollProgressEnabled },
-    christmas: { checked: isChristmasEnabled, onChange: () => toggleChristmas() },
-    bgmWidget: { checked: bgmWidget, onChange: setBgmWidgetEnabled },
-    masterMotion: { checked: masterMotion, onChange: setMasterMotionEnabled },
-    wave: { checked: wave, onChange: setWaveEnabled },
-  };
-
-  const numberBindings: Record<string, { value: number; onApply: (value: number) => void }> = {
-    fontSize: { value: fontSize, onApply: setFontSize },
-    lineHeight: { value: lineHeight, onApply: setLineHeight },
-    measure: { value: measure, onApply: setMeasure },
-  };
-
-  // Open on Reading for article pages and General everywhere else.
-  const [section, setSection] = useState<SettingSection>('general');
   useEffect(() => {
-    if (!open) return;
-    setSection(document.querySelector('article[data-pagefind-body]') ? 'reader' : 'general');
+    if (open) setLoaded(true);
   }, [open]);
 
-  // Initialize settings from localStorage on mount
-  useEffect(() => {
-    initSettings();
-  }, []);
-
-  // floating-ui: dismiss on ESC / outside click
-  const { refs, context } = useFloating({
-    open,
-    onOpenChange: (next) => {
-      if (!next) closeModal();
-    },
-  });
-  const dismiss = useDismiss(context, {
-    outsidePressEvent: 'mousedown',
-    // Exclude the settings toggle button in FloatingGroup to prevent toggle/dismiss race
-    outsidePress: (event) => {
-      const target = event.target as HTMLElement;
-      return !target.closest('[data-settings-toggle]');
-    },
-  });
-  const role = useRole(context, { role: 'dialog' });
-  const { getFloatingProps } = useInteractions([dismiss, role]);
-
-  const renderControl = (item: SettingItem) => {
-    const disabled = Boolean(item.disabledByMasterMotion && masterMotion);
-
-    switch (item.type) {
-      case 'segmented':
-        return (
-          <div className="flex flex-wrap gap-1">
-            {item.options?.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => setFontPreset(option.value as FontPreset)}
-                aria-pressed={fontPreset === option.value}
-                className={cn(
-                  'rounded-md px-2.5 py-1 text-xs transition-colors',
-                  fontPreset === option.value
-                    ? 'bg-primary text-primary-foreground'
-                    : 'bg-muted text-muted-foreground hover:bg-accent hover:text-foreground',
-                )}
-              >
-                {t(option.i18nKey)}
-              </button>
-            ))}
-          </div>
-        );
-      case 'number': {
-        const binding = numberBindings[item.key];
-        if (!binding) return null;
-        return (
-          <NumberField
-            label={t(item.i18nKey)}
-            value={binding.value}
-            step={item.step ?? 1}
-            unit={item.unit}
-            onApply={binding.onApply}
-          />
-        );
-      }
-      case 'switch': {
-        const binding = switchBindings[item.key];
-        if (!binding) return null;
-        return (
-          <Switch
-            checked={binding.checked}
-            onCheckedChange={binding.onChange}
-            disabled={disabled}
-            aria-label={t(item.i18nKey)}
-          />
-        );
-      }
-    }
-  };
-
-  const items = SETTINGS_REGISTRY.filter((item) => item.section === section && isSettingVisible(item));
-
+  if (!loaded) return null;
   return (
-    <AnimatePresence>
-      {open && (
-        <FloatingFocusManager context={context} modal={false}>
-          <motion.div
-            ref={refs.setFloating}
-            {...getFloatingProps()}
-            className="fixed right-16 bottom-20 z-40 w-[320px] max-w-[calc(100vw-5rem)]"
-            initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.95 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.95 }}
-            transition={shouldReduceMotion ? { duration: 0.15 } : microReboundPreset}
-          >
-            <div className="rounded-2xl border border-border bg-popover p-4 text-popover-foreground shadow-xl">
-              {/* Header */}
-              <div className="mb-3 flex items-center justify-between">
-                <h2 className="font-semibold text-sm">{t('settings.title')}</h2>
-                <button
-                  type="button"
-                  className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                  onClick={closeModal}
-                  aria-label={t('settings.closePanel')}
-                >
-                  <Icon icon="ri:close-line" className="h-4 w-4" />
-                </button>
-              </div>
-
-              {/* Section tabs */}
-              <div className="mb-3 flex gap-1 rounded-lg bg-muted p-1">
-                {SECTIONS.map((key) => (
-                  <button
-                    key={key}
-                    type="button"
-                    onClick={() => setSection(key)}
-                    className={cn(
-                      'flex-1 rounded-md px-3 py-1 font-medium text-xs transition-colors',
-                      section === key
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground',
-                    )}
-                  >
-                    {t(key === 'reader' ? 'settings.reader' : 'settings.general')}
-                  </button>
-                ))}
-              </div>
-
-              {/* Setting items */}
-              <div className="flex flex-col divide-y divide-border">
-                {items.map((item) => {
-                  const disabled = Boolean(item.disabledByMasterMotion && masterMotion);
-                  return (
-                    <div key={item.key} className="py-2.5 first:pt-1 last:pb-1">
-                      <div className="flex items-center justify-between gap-3">
-                        <span className={cn('text-sm', disabled && 'opacity-50')}>{t(item.i18nKey)}</span>
-                        {item.type !== 'segmented' && renderControl(item)}
-                      </div>
-                      {item.type === 'segmented' && <div className="mt-2">{renderControl(item)}</div>}
-                      {disabled && (
-                        <p className="mt-1 text-muted-foreground text-xs">{t('settings.waveDisabledByMasterMotion')}</p>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-
-              {/* Reader section: reset */}
-              {section === 'reader' && (
-                <button
-                  type="button"
-                  onClick={resetReaderPreferences}
-                  className="mt-3 w-full rounded-md border border-input py-1.5 text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground"
-                >
-                  {t('settings.reset')}
-                </button>
-              )}
-            </div>
-          </motion.div>
-        </FloatingFocusManager>
-      )}
-    </AnimatePresence>
+    <Suspense fallback={null}>
+      <SettingsPanelContent />
+    </Suspense>
   );
 }

--- a/src/components/settings/SettingsPanelContent.tsx
+++ b/src/components/settings/SettingsPanelContent.tsx
@@ -38,6 +38,7 @@ import {
   setWaveEnabled,
   waveEnabled,
 } from '@store/settings';
+import { READER_CUSTOM_MEASURE } from '@store/settings-constants';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { useEffect, useState } from 'react';
 import { NumberField } from './NumberField';
@@ -71,10 +72,21 @@ export default function SettingsPanelContent() {
     wave: { checked: wave, onChange: setWaveEnabled },
   };
 
-  const numberBindings: Record<string, { value: number; onApply: (value: number) => void }> = {
-    fontSize: { value: fontSize, onApply: setFontSize },
-    lineHeight: { value: lineHeight, onApply: setLineHeight },
-    measure: { value: measure, onApply: setMeasure },
+  const numberBindings: Record<
+    string,
+    {
+      value: number | null;
+      onApply: (value: number | null) => void;
+      emptyValue?: { label: string; fallback: number };
+    }
+  > = {
+    fontSize: { value: fontSize, onApply: (value) => value !== null && setFontSize(value) },
+    lineHeight: { value: lineHeight, onApply: (value) => value !== null && setLineHeight(value) },
+    measure: {
+      value: measure,
+      onApply: setMeasure,
+      emptyValue: { label: t('settings.auto'), fallback: READER_CUSTOM_MEASURE },
+    },
   };
 
   // Open on Reading for pages with prose content and General everywhere else.
@@ -136,6 +148,7 @@ export default function SettingsPanelContent() {
             value={binding.value}
             step={item.step ?? 1}
             unit={item.unit}
+            emptyValue={binding.emptyValue}
             onApply={binding.onApply}
           />
         );

--- a/src/components/settings/SettingsPanelContent.tsx
+++ b/src/components/settings/SettingsPanelContent.tsx
@@ -1,7 +1,7 @@
 /**
  * Settings Center popover body.
  *
- * This is the single container for reader and general preferences; see CONTEXT.md.
+ * This is the single container for reader and general preferences.
  * Controls render from the declarative registry and the modal store owns visibility.
  * Lazy-loaded by SettingsPanel so its floating-ui / react-hook-form / zod deps stay out of
  * the first-paint bundle until the panel is first opened.

--- a/src/components/settings/SettingsPanelContent.tsx
+++ b/src/components/settings/SettingsPanelContent.tsx
@@ -1,0 +1,241 @@
+/**
+ * Settings Center popover body.
+ *
+ * This is the single container for reader and general preferences; see CONTEXT.md.
+ * Controls render from the declarative registry and the modal store owns visibility.
+ * Lazy-loaded by SettingsPanel so its floating-ui / react-hook-form / zod deps stay out of
+ * the first-paint bundle until the panel is first opened.
+ */
+
+import { Switch } from '@components/ui/switch';
+import { microReboundPreset } from '@constants/anim/spring';
+import { FloatingFocusManager, useDismiss, useFloating, useInteractions, useRole } from '@floating-ui/react';
+import { useTranslation } from '@hooks/useTranslation';
+import { Icon } from '@iconify/react';
+import { cn } from '@lib/utils';
+import { useStore } from '@nanostores/react';
+import { christmasEnabled, toggleChristmas } from '@store/christmas';
+import { $isSettingsOpen, closeModal } from '@store/modal';
+import {
+  bgmWidgetEnabled,
+  type FontPreset,
+  masterMotionEnabled,
+  readerFontPreset,
+  readerFontSize,
+  readerJustify,
+  readerLineHeight,
+  readerMeasure,
+  resetReaderPreferences,
+  scrollProgressEnabled,
+  setBgmWidgetEnabled,
+  setFontPreset,
+  setFontSize,
+  setJustify,
+  setLineHeight,
+  setMasterMotionEnabled,
+  setMeasure,
+  setScrollProgressEnabled,
+  setWaveEnabled,
+  waveEnabled,
+} from '@store/settings';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import { useEffect, useState } from 'react';
+import { NumberField } from './NumberField';
+import { isSettingVisible, SETTINGS_REGISTRY, type SettingItem, type SettingSection } from './registry';
+
+const SECTIONS: SettingSection[] = ['reader', 'general'];
+
+export default function SettingsPanelContent() {
+  const { t } = useTranslation();
+  const open = useStore($isSettingsOpen);
+  const shouldReduceMotion = useReducedMotion();
+
+  // Store bindings
+  const fontPreset = useStore(readerFontPreset);
+  const fontSize = useStore(readerFontSize);
+  const lineHeight = useStore(readerLineHeight);
+  const measure = useStore(readerMeasure);
+  const justify = useStore(readerJustify);
+  const scrollProgress = useStore(scrollProgressEnabled);
+  const bgmWidget = useStore(bgmWidgetEnabled);
+  const masterMotion = useStore(masterMotionEnabled);
+  const wave = useStore(waveEnabled);
+  const isChristmasEnabled = useStore(christmasEnabled);
+
+  const switchBindings: Record<string, { checked: boolean; onChange: (checked: boolean) => void }> = {
+    justify: { checked: justify, onChange: setJustify },
+    scrollProgress: { checked: scrollProgress, onChange: setScrollProgressEnabled },
+    christmas: { checked: isChristmasEnabled, onChange: () => toggleChristmas() },
+    bgmWidget: { checked: bgmWidget, onChange: setBgmWidgetEnabled },
+    masterMotion: { checked: masterMotion, onChange: setMasterMotionEnabled },
+    wave: { checked: wave, onChange: setWaveEnabled },
+  };
+
+  const numberBindings: Record<string, { value: number; onApply: (value: number) => void }> = {
+    fontSize: { value: fontSize, onApply: setFontSize },
+    lineHeight: { value: lineHeight, onApply: setLineHeight },
+    measure: { value: measure, onApply: setMeasure },
+  };
+
+  // Open on Reading for pages with prose content and General everywhere else.
+  const [section, setSection] = useState<SettingSection>('general');
+  useEffect(() => {
+    if (!open) return;
+    setSection(document.querySelector('[data-pagefind-body]') ? 'reader' : 'general');
+  }, [open]);
+
+  // floating-ui: dismiss on ESC / outside click
+  const { refs, context } = useFloating({
+    open,
+    onOpenChange: (next) => {
+      if (!next) closeModal();
+    },
+  });
+  const dismiss = useDismiss(context, {
+    outsidePressEvent: 'mousedown',
+    // Exclude the settings toggle button in FloatingGroup to prevent toggle/dismiss race
+    outsidePress: (event) => {
+      const target = event.target as HTMLElement;
+      return !target.closest('[data-settings-toggle]');
+    },
+  });
+  const role = useRole(context, { role: 'dialog' });
+  const { getFloatingProps } = useInteractions([dismiss, role]);
+
+  const renderControl = (item: SettingItem) => {
+    const disabled = Boolean(item.disabledByMasterMotion && masterMotion);
+
+    switch (item.type) {
+      case 'segmented':
+        return (
+          <div className="flex flex-wrap gap-1">
+            {item.options?.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setFontPreset(option.value as FontPreset)}
+                aria-pressed={fontPreset === option.value}
+                className={cn(
+                  'rounded-md px-2.5 py-1 text-xs transition-colors',
+                  fontPreset === option.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:bg-accent hover:text-foreground',
+                )}
+              >
+                {t(option.i18nKey)}
+              </button>
+            ))}
+          </div>
+        );
+      case 'number': {
+        const binding = numberBindings[item.key];
+        if (!binding) return null;
+        return (
+          <NumberField
+            label={t(item.i18nKey)}
+            value={binding.value}
+            step={item.step ?? 1}
+            unit={item.unit}
+            onApply={binding.onApply}
+          />
+        );
+      }
+      case 'switch': {
+        const binding = switchBindings[item.key];
+        if (!binding) return null;
+        return (
+          <Switch
+            checked={binding.checked}
+            onCheckedChange={binding.onChange}
+            disabled={disabled}
+            aria-label={t(item.i18nKey)}
+          />
+        );
+      }
+    }
+  };
+
+  const items = SETTINGS_REGISTRY.filter((item) => item.section === section && isSettingVisible(item));
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <FloatingFocusManager context={context} modal={false}>
+          <motion.div
+            ref={refs.setFloating}
+            {...getFloatingProps()}
+            className="fixed right-16 bottom-20 z-40 w-[320px] max-w-[calc(100vw-5rem)]"
+            initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.95 }}
+            transition={shouldReduceMotion ? { duration: 0.15 } : microReboundPreset}
+          >
+            <div className="max-h-[calc(100dvh-6rem)] overflow-y-auto overscroll-contain rounded-2xl border border-border bg-popover p-4 text-popover-foreground shadow-xl">
+              {/* Header */}
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="font-semibold text-sm">{t('settings.title')}</h2>
+                <button
+                  type="button"
+                  className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  onClick={closeModal}
+                  aria-label={t('settings.closePanel')}
+                >
+                  <Icon icon="ri:close-line" className="h-4 w-4" />
+                </button>
+              </div>
+
+              {/* Section tabs */}
+              <div className="mb-3 flex gap-1 rounded-lg bg-muted p-1">
+                {SECTIONS.map((key) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setSection(key)}
+                    className={cn(
+                      'flex-1 rounded-md px-3 py-1 font-medium text-xs transition-colors',
+                      section === key
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    {t(key === 'reader' ? 'settings.reader' : 'settings.general')}
+                  </button>
+                ))}
+              </div>
+
+              {/* Setting items */}
+              <div className="flex flex-col divide-y divide-border">
+                {items.map((item) => {
+                  const disabled = Boolean(item.disabledByMasterMotion && masterMotion);
+                  return (
+                    <div key={item.key} className="py-2.5 first:pt-1 last:pb-1">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className={cn('text-sm', disabled && 'opacity-50')}>{t(item.i18nKey)}</span>
+                        {item.type !== 'segmented' && renderControl(item)}
+                      </div>
+                      {item.type === 'segmented' && <div className="mt-2">{renderControl(item)}</div>}
+                      {disabled && (
+                        <p className="mt-1 text-muted-foreground text-xs">{t('settings.waveDisabledByMasterMotion')}</p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Reader section: reset */}
+              {section === 'reader' && (
+                <button
+                  type="button"
+                  onClick={resetReaderPreferences}
+                  className="mt-3 w-full rounded-md border border-input py-1.5 text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground"
+                >
+                  {t('settings.reset')}
+                </button>
+              )}
+            </div>
+          </motion.div>
+        </FloatingFocusManager>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/settings/SettingsPanelContent.tsx
+++ b/src/components/settings/SettingsPanelContent.tsx
@@ -121,22 +121,30 @@ export default function SettingsPanelContent() {
       case 'segmented':
         return (
           <div className="flex flex-wrap gap-1">
-            {item.options?.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => setFontPreset(option.value as FontPreset)}
-                aria-pressed={fontPreset === option.value}
-                className={cn(
-                  'rounded-md px-2.5 py-1 text-xs transition-colors',
-                  fontPreset === option.value
-                    ? 'bg-primary text-primary-foreground'
-                    : 'bg-muted text-muted-foreground hover:bg-accent hover:text-foreground',
-                )}
-              >
-                {t(option.i18nKey)}
-              </button>
-            ))}
+            {item.options?.map((option) => {
+              const active = fontPreset === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setFontPreset(option.value as FontPreset)}
+                  aria-pressed={active}
+                  className={cn(
+                    'relative rounded-md px-2.5 py-1 text-xs transition-colors',
+                    active ? 'text-primary-foreground' : 'bg-muted text-muted-foreground hover:bg-accent hover:text-foreground',
+                  )}
+                >
+                  {active && (
+                    <motion.span
+                      layoutId="settings-font-preset-pill"
+                      className="absolute inset-0 rounded-md bg-primary"
+                      transition={shouldReduceMotion ? { duration: 0 } : microReboundPreset}
+                    />
+                  )}
+                  <span className="relative">{t(option.i18nKey)}</span>
+                </button>
+              );
+            })}
           </div>
         );
       case 'number': {
@@ -183,13 +191,13 @@ export default function SettingsPanelContent() {
             exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.95 }}
             transition={shouldReduceMotion ? { duration: 0.15 } : microReboundPreset}
           >
-            <div className="max-h-[calc(100dvh-6rem)] overflow-y-auto overscroll-contain rounded-2xl border border-border bg-popover p-4 text-popover-foreground shadow-xl">
+            <div className="flex h-[calc(100dvh-6rem)] max-h-96 flex-col overflow-hidden rounded-2xl border border-border bg-popover p-4 text-popover-foreground shadow-xl">
               {/* Header */}
               <div className="mb-3 flex items-center justify-between">
                 <h2 className="font-semibold text-sm">{t('settings.title')}</h2>
                 <button
                   type="button"
-                  className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  className="relative rounded-full p-1 text-muted-foreground transition-[background-color,color,transform] after:absolute after:-inset-2 after:rounded-full after:content-[''] hover:bg-accent hover:text-foreground active:scale-[0.96]"
                   onClick={closeModal}
                   aria-label={t('settings.closePanel')}
                 >
@@ -199,52 +207,73 @@ export default function SettingsPanelContent() {
 
               {/* Section tabs */}
               <div className="mb-3 flex gap-1 rounded-lg bg-muted p-1">
-                {SECTIONS.map((key) => (
-                  <button
-                    key={key}
-                    type="button"
-                    onClick={() => setSection(key)}
-                    className={cn(
-                      'flex-1 rounded-md px-3 py-1 font-medium text-xs transition-colors',
-                      section === key
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground',
-                    )}
-                  >
-                    {t(key === 'reader' ? 'settings.reader' : 'settings.general')}
-                  </button>
-                ))}
-              </div>
-
-              {/* Setting items */}
-              <div className="flex flex-col divide-y divide-border">
-                {items.map((item) => {
-                  const disabled = Boolean(item.disabledByMasterMotion && masterMotion);
+                {SECTIONS.map((key) => {
+                  const active = section === key;
                   return (
-                    <div key={item.key} className="py-2.5 first:pt-1 last:pb-1">
-                      <div className="flex items-center justify-between gap-3">
-                        <span className={cn('text-sm', disabled && 'opacity-50')}>{t(item.i18nKey)}</span>
-                        {item.type !== 'segmented' && renderControl(item)}
-                      </div>
-                      {item.type === 'segmented' && <div className="mt-2">{renderControl(item)}</div>}
-                      {disabled && (
-                        <p className="mt-1 text-muted-foreground text-xs">{t('settings.waveDisabledByMasterMotion')}</p>
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => setSection(key)}
+                      className={cn(
+                        'relative flex-1 rounded-md px-3 py-1 font-medium text-xs transition-colors',
+                        active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
                       )}
-                    </div>
+                    >
+                      {active && (
+                        <motion.span
+                          layoutId="settings-section-pill"
+                          className="absolute inset-0 rounded-md bg-background shadow-sm"
+                          transition={shouldReduceMotion ? { duration: 0 } : microReboundPreset}
+                        />
+                      )}
+                      <span className="relative">{t(key === 'reader' ? 'settings.reader' : 'settings.general')}</span>
+                    </button>
                   );
                 })}
               </div>
 
-              {/* Reader section: reset */}
-              {section === 'reader' && (
-                <button
-                  type="button"
-                  onClick={resetReaderPreferences}
-                  className="mt-3 w-full rounded-md border border-input py-1.5 text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-foreground"
-                >
-                  {t('settings.reset')}
-                </button>
-              )}
+              {/* Setting items */}
+              <div className="min-h-0 flex-1">
+                <AnimatePresence mode="wait" initial={false}>
+                  <motion.div
+                    key={section}
+                    className="h-full overflow-y-auto overscroll-contain"
+                    initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
+                    transition={{ duration: 0.15, ease: 'easeOut' }}
+                  >
+                    <div className="flex flex-col divide-y divide-border">
+                      {items.map((item) => {
+                        const disabled = Boolean(item.disabledByMasterMotion && masterMotion);
+                        return (
+                          <div key={item.key} className="py-2.5 first:pt-1 last:pb-1">
+                            <div className="flex items-center justify-between gap-3">
+                              <span className={cn('text-sm', disabled && 'opacity-50')}>{t(item.i18nKey)}</span>
+                              {item.type !== 'segmented' && renderControl(item)}
+                            </div>
+                            {item.type === 'segmented' && <div className="mt-2">{renderControl(item)}</div>}
+                            {disabled && (
+                              <p className="mt-1 text-muted-foreground text-xs">{t('settings.waveDisabledByMasterMotion')}</p>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+
+                    {/* Reader section: reset */}
+                    {section === 'reader' && (
+                      <button
+                        type="button"
+                        onClick={resetReaderPreferences}
+                        className="mt-3 w-full rounded-md border border-input py-1.5 text-muted-foreground text-xs transition-[background-color,color,transform] hover:bg-accent hover:text-foreground active:scale-[0.96]"
+                      >
+                        {t('settings.reset')}
+                      </button>
+                    )}
+                  </motion.div>
+                </AnimatePresence>
+              </div>
             </div>
           </motion.div>
         </FloatingFocusManager>

--- a/src/components/settings/registry.ts
+++ b/src/components/settings/registry.ts
@@ -1,0 +1,136 @@
+/**
+ * Settings Registry
+ *
+ * Declarative registry for the Settings Center; see docs/adr/0001.
+ * Add settings here and implement their application logic in src/store/settings.ts.
+ */
+
+import { bgmConfig, christmasConfig } from '@constants/site-config';
+import { GENERAL_DEFAULTS, READER_DEFAULTS } from '@store/settings';
+import type { TranslationKey } from '@/i18n/types';
+
+export type SettingSection = 'reader' | 'general';
+export type SettingType = 'segmented' | 'number' | 'switch';
+
+export interface SettingOption {
+  value: string;
+  i18nKey: TranslationKey;
+}
+
+export interface SettingItem {
+  /** Corresponding preference key in the settings store. */
+  key: string;
+  section: SettingSection;
+  type: SettingType;
+  i18nKey: TranslationKey;
+  default: string | number | boolean;
+  /** Display unit for numeric controls; line height has no unit. */
+  unit?: string;
+  /** Step size for numeric controls. */
+  step?: number;
+  /** Options for segmented controls. */
+  options?: SettingOption[];
+  /** Build-time feature gate that hides unavailable settings. */
+  gatedBy?: 'christmas' | 'bgm';
+  /** Disable this setting while the master motion preference is enabled. */
+  disabledByMasterMotion?: boolean;
+}
+
+export const SETTINGS_REGISTRY: SettingItem[] = [
+  // Reader preferences
+  {
+    key: 'fontPreset',
+    section: 'reader',
+    type: 'segmented',
+    i18nKey: 'settings.fontPreset',
+    default: READER_DEFAULTS.fontPreset,
+    options: [
+      { value: 'round', i18nKey: 'settings.fontPreset.round' },
+      { value: 'system', i18nKey: 'settings.fontPreset.system' },
+      { value: 'serif', i18nKey: 'settings.fontPreset.serif' },
+      { value: 'wenkai', i18nKey: 'settings.fontPreset.wenkai' },
+    ],
+  },
+  {
+    key: 'fontSize',
+    section: 'reader',
+    type: 'number',
+    i18nKey: 'settings.fontSize',
+    default: READER_DEFAULTS.fontSize,
+    unit: 'px',
+    step: 1,
+  },
+  {
+    key: 'lineHeight',
+    section: 'reader',
+    type: 'number',
+    i18nKey: 'settings.lineHeight',
+    default: READER_DEFAULTS.lineHeight,
+    step: 0.1,
+  },
+  {
+    key: 'measure',
+    section: 'reader',
+    type: 'number',
+    i18nKey: 'settings.measure',
+    default: READER_DEFAULTS.measure,
+    unit: 'ch',
+    step: 1,
+  },
+  {
+    key: 'justify',
+    section: 'reader',
+    type: 'switch',
+    i18nKey: 'settings.justify',
+    default: READER_DEFAULTS.justify,
+  },
+
+  // General preferences
+  {
+    key: 'scrollProgress',
+    section: 'general',
+    type: 'switch',
+    i18nKey: 'settings.scrollProgress',
+    default: GENERAL_DEFAULTS.scrollProgress,
+  },
+  {
+    key: 'christmas',
+    section: 'general',
+    type: 'switch',
+    i18nKey: 'settings.christmas',
+    default: true,
+    gatedBy: 'christmas',
+  },
+  {
+    key: 'bgmWidget',
+    section: 'general',
+    type: 'switch',
+    i18nKey: 'settings.bgmWidget',
+    default: GENERAL_DEFAULTS.bgmWidget,
+    gatedBy: 'bgm',
+  },
+  {
+    key: 'masterMotion',
+    section: 'general',
+    type: 'switch',
+    i18nKey: 'settings.masterMotion',
+    default: GENERAL_DEFAULTS.masterMotion,
+  },
+  {
+    key: 'wave',
+    section: 'general',
+    type: 'switch',
+    i18nKey: 'settings.wave',
+    default: GENERAL_DEFAULTS.wave,
+    disabledByMasterMotion: true,
+  },
+];
+
+/**
+ * Hide settings whose build-time feature is unavailable.
+ */
+export function isSettingVisible(item: SettingItem): boolean {
+  if (item.gatedBy === 'christmas') return christmasConfig.enabled;
+  if (item.gatedBy === 'bgm') return bgmConfig.enabled && bgmConfig.audio.length > 0;
+  return true;
+}

--- a/src/components/settings/registry.ts
+++ b/src/components/settings/registry.ts
@@ -6,7 +6,6 @@
  */
 
 import { bgmConfig, christmasConfig } from '@constants/site-config';
-import { GENERAL_DEFAULTS, READER_DEFAULTS } from '@store/settings';
 import type { TranslationKey } from '@/i18n/types';
 
 export type SettingSection = 'reader' | 'general';
@@ -23,7 +22,6 @@ export interface SettingItem {
   section: SettingSection;
   type: SettingType;
   i18nKey: TranslationKey;
-  default: string | number | boolean;
   /** Display unit for numeric controls; line height has no unit. */
   unit?: string;
   /** Step size for numeric controls. */
@@ -43,7 +41,6 @@ export const SETTINGS_REGISTRY: SettingItem[] = [
     section: 'reader',
     type: 'segmented',
     i18nKey: 'settings.fontPreset',
-    default: READER_DEFAULTS.fontPreset,
     options: [
       { value: 'round', i18nKey: 'settings.fontPreset.round' },
       { value: 'system', i18nKey: 'settings.fontPreset.system' },
@@ -56,7 +53,6 @@ export const SETTINGS_REGISTRY: SettingItem[] = [
     section: 'reader',
     type: 'number',
     i18nKey: 'settings.fontSize',
-    default: READER_DEFAULTS.fontSize,
     unit: 'px',
     step: 1,
   },
@@ -65,7 +61,6 @@ export const SETTINGS_REGISTRY: SettingItem[] = [
     section: 'reader',
     type: 'number',
     i18nKey: 'settings.lineHeight',
-    default: READER_DEFAULTS.lineHeight,
     step: 0.1,
   },
   {
@@ -73,7 +68,6 @@ export const SETTINGS_REGISTRY: SettingItem[] = [
     section: 'reader',
     type: 'number',
     i18nKey: 'settings.measure',
-    default: READER_DEFAULTS.measure,
     unit: 'ch',
     step: 1,
   },
@@ -82,7 +76,6 @@ export const SETTINGS_REGISTRY: SettingItem[] = [
     section: 'reader',
     type: 'switch',
     i18nKey: 'settings.justify',
-    default: READER_DEFAULTS.justify,
   },
 
   // General preferences
@@ -91,14 +84,12 @@ export const SETTINGS_REGISTRY: SettingItem[] = [
     section: 'general',
     type: 'switch',
     i18nKey: 'settings.scrollProgress',
-    default: GENERAL_DEFAULTS.scrollProgress,
   },
   {
     key: 'christmas',
     section: 'general',
     type: 'switch',
     i18nKey: 'settings.christmas',
-    default: true,
     gatedBy: 'christmas',
   },
   {
@@ -106,7 +97,6 @@ export const SETTINGS_REGISTRY: SettingItem[] = [
     section: 'general',
     type: 'switch',
     i18nKey: 'settings.bgmWidget',
-    default: GENERAL_DEFAULTS.bgmWidget,
     gatedBy: 'bgm',
   },
   {
@@ -114,14 +104,12 @@ export const SETTINGS_REGISTRY: SettingItem[] = [
     section: 'general',
     type: 'switch',
     i18nKey: 'settings.masterMotion',
-    default: GENERAL_DEFAULTS.masterMotion,
   },
   {
     key: 'wave',
     section: 'general',
     type: 'switch',
     i18nKey: 'settings.wave',
-    default: GENERAL_DEFAULTS.wave,
     disabledByMasterMotion: true,
   },
 ];

--- a/src/components/ui/cover/Cover.astro
+++ b/src/components/ui/cover/Cover.astro
@@ -67,7 +67,7 @@ const pageStatsConfig = href ? createArticleStatsConfig(href) : null;
             <p class="mt-3 flex flex-wrap items-center justify-center gap-4 md:text-xs">
               <span class="flex items-center gap-1">
                 <Icon name="fa6-solid:calendar-days" />
-                {t(locale, "post.publishedAt", { date: date && displayDate.datetime(date) })}
+                {t(locale, "post.publishedAt", { date: date ? displayDate.datetime(date) : '' })}
               </span>
               {updated && (
                 <span class="flex items-center gap-1">
@@ -76,7 +76,7 @@ const pageStatsConfig = href ? createArticleStatsConfig(href) : null;
                 </span>
               )}
               <span class="flex items-center gap-1">
-                <Icon name="fa6-solid:pen-nib" /> {t(locale, "post.wordCount", { count: readState?.words })}
+                <Icon name="fa6-solid:pen-nib" /> {t(locale, "post.wordCount", { count: readState?.words ?? 0 })}
               </span>
               <span class="flex items-center gap-1">
                 <Icon name="fa6-solid:clock" />

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -19,10 +19,11 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors',
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-[background-color,transform]',
       'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
       'disabled:cursor-not-allowed disabled:opacity-50',
       'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'active:scale-[0.96]',
       className,
     )}
     {...props}
@@ -30,7 +31,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform duration-200 ease-[cubic-bezier(0.2,0,0,1)]',
         'data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
       )}
     />

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,41 @@
+/**
+ * Switch Component
+ *
+ * shadcn-style wrapper around @radix-ui/react-switch.
+ *
+ * @example
+ * ```tsx
+ * <Switch checked={enabled} onCheckedChange={setEnabled} />
+ * ```
+ */
+
+import { cn } from '@lib/utils';
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import * as React from 'react';
+
+const Switch = React.forwardRef<
+  React.ComponentRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors',
+      'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+      'disabled:cursor-not-allowed disabled:opacity-50',
+      'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+        'data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/src/constants/code-block.ts
+++ b/src/constants/code-block.ts
@@ -1,0 +1,1 @@
+export const COLLAPSE_LINE_THRESHOLD = 8;

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -214,6 +214,7 @@ export const uiStrings: UIStrings = {
   'settings.fontSize': 'Font size',
   'settings.lineHeight': 'Line height',
   'settings.measure': 'Measure',
+  'settings.auto': 'Auto',
   'settings.justify': 'Justify',
   'settings.scrollProgress': 'Scroll progress bar',
   'settings.christmas': 'Christmas effects',

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -123,6 +123,8 @@ export const uiStrings: UIStrings = {
   'code.wrapLines': 'Word wrap',
   'code.viewSource': 'View source',
   'code.viewRendered': 'View rendered',
+  'code.collapse': 'Collapse code',
+  'code.expand': 'Expand code',
 
   // ── Diagram / Infographic ───────────────────────────────────
   'diagram.fullscreen': 'Full screen',
@@ -197,6 +199,30 @@ export const uiStrings: UIStrings = {
   'floating.christmas': 'Toggle Christmas effects',
   'floating.bgm': 'Background music',
   'floating.toggleToolbar': 'Toggle toolbar',
+  'floating.settings': 'Settings',
+
+  // ── Settings Panel ────────────────────────────────────────
+  'settings.title': 'Settings',
+  'settings.reader': 'Reading',
+  'settings.general': 'General',
+  'settings.closePanel': 'Close settings panel',
+  'settings.fontPreset': 'Font preset',
+  'settings.fontPreset.round': 'Rounded',
+  'settings.fontPreset.system': 'System',
+  'settings.fontPreset.serif': 'Serif',
+  'settings.fontPreset.wenkai': 'WenKai',
+  'settings.fontSize': 'Font size',
+  'settings.lineHeight': 'Line height',
+  'settings.measure': 'Measure',
+  'settings.justify': 'Justify',
+  'settings.scrollProgress': 'Scroll progress bar',
+  'settings.christmas': 'Christmas effects',
+  'settings.bgmWidget': 'BGM widget',
+  'settings.masterMotion': 'Reduce motion',
+  'settings.wave': 'Cover waves',
+  'settings.reset': 'Reset to default',
+  'settings.waveDisabledByMasterMotion': 'Unavailable while "Reduce motion" is on',
+  'settings.invalidNumber': 'Enter a positive number',
 
   // ── Announcement ────────────────────────────────────────────
   'announcement.title': 'Announcements',

--- a/src/i18n/translations/ja.ts
+++ b/src/i18n/translations/ja.ts
@@ -123,6 +123,8 @@ export const uiStrings: UIStrings = {
   'code.wrapLines': '文字の折り返し',
   'code.viewSource': 'ソースを表示',
   'code.viewRendered': 'レンダリングされた表示',
+  'code.collapse': 'コードを折りたたむ',
+  'code.expand': 'コードを展開',
 
   // ── 図表 / インフォグラフィック ───────────────────────────────────
   'diagram.fullscreen': 'フルスクリーン',
@@ -197,6 +199,30 @@ export const uiStrings: UIStrings = {
   'floating.christmas': 'クリスマスエフェクトに切り替え',
   'floating.bgm': 'BGM',
   'floating.toggleToolbar': 'ツールバーを切り替え',
+  'floating.settings': '設定',
+
+  // ── Settings Panel ────────────────────────────────────────
+  'settings.title': '設定',
+  'settings.reader': '読書',
+  'settings.general': '一般',
+  'settings.closePanel': '設定パネルを閉じる',
+  'settings.fontPreset': 'フォントプリセット',
+  'settings.fontPreset.round': '丸ゴシック',
+  'settings.fontPreset.system': 'システム',
+  'settings.fontPreset.serif': 'セリフ',
+  'settings.fontPreset.wenkai': '文楷',
+  'settings.fontSize': '文字サイズ',
+  'settings.lineHeight': '行間',
+  'settings.measure': '行幅',
+  'settings.justify': '両端揃え',
+  'settings.scrollProgress': 'スクロール進捗バー',
+  'settings.christmas': 'クリスマスエフェクト',
+  'settings.bgmWidget': 'BGM ウィジェット',
+  'settings.masterMotion': 'アニメーションを減らす',
+  'settings.wave': 'カバーの波',
+  'settings.reset': 'デフォルトにリセット',
+  'settings.waveDisabledByMasterMotion': '「アニメーションを減らす」がオンの間は使用できません',
+  'settings.invalidNumber': '正の数を入力してください',
 
   // ── お知らせ ────────────────────────────────────────────
   'announcement.title': 'お知らせ',

--- a/src/i18n/translations/ja.ts
+++ b/src/i18n/translations/ja.ts
@@ -214,6 +214,7 @@ export const uiStrings: UIStrings = {
   'settings.fontSize': '文字サイズ',
   'settings.lineHeight': '行間',
   'settings.measure': '行幅',
+  'settings.auto': '自動',
   'settings.justify': '両端揃え',
   'settings.scrollProgress': 'スクロール進捗バー',
   'settings.christmas': 'クリスマスエフェクト',

--- a/src/i18n/translations/zh.ts
+++ b/src/i18n/translations/zh.ts
@@ -122,6 +122,8 @@ export const uiStrings = {
   'code.wrapLines': '自动换行',
   'code.viewSource': '查看源码',
   'code.viewRendered': '查看渲染结果',
+  'code.collapse': '收起代码',
+  'code.expand': '展开代码',
 
   // ── Diagram / Infographic ───────────────────────────────────
   'diagram.fullscreen': '全屏查看',
@@ -196,6 +198,30 @@ export const uiStrings = {
   'floating.christmas': '切换圣诞特效',
   'floating.bgm': '背景音乐',
   'floating.toggleToolbar': '展开/收起工具栏',
+  'floating.settings': '设置',
+
+  // ── Settings Panel ────────────────────────────────────────
+  'settings.title': '设置',
+  'settings.reader': '阅读',
+  'settings.general': '通用',
+  'settings.closePanel': '关闭设置面板',
+  'settings.fontPreset': '字体预设',
+  'settings.fontPreset.round': '圆体',
+  'settings.fontPreset.system': '系统黑体',
+  'settings.fontPreset.serif': '衬线',
+  'settings.fontPreset.wenkai': '文楷',
+  'settings.fontSize': '字号',
+  'settings.lineHeight': '行距',
+  'settings.measure': '行宽',
+  'settings.justify': '两端对齐',
+  'settings.scrollProgress': '滚动进度条',
+  'settings.christmas': '圣诞特效',
+  'settings.bgmWidget': '背景音乐控件',
+  'settings.masterMotion': '减弱动画',
+  'settings.wave': '封面海浪',
+  'settings.reset': '重置为默认',
+  'settings.waveDisabledByMasterMotion': '「减弱动画」开启时不可用',
+  'settings.invalidNumber': '请输入正数',
 
   // ── Announcement ────────────────────────────────────────────
   'announcement.title': '公告',

--- a/src/i18n/translations/zh.ts
+++ b/src/i18n/translations/zh.ts
@@ -213,6 +213,7 @@ export const uiStrings = {
   'settings.fontSize': '字号',
   'settings.lineHeight': '行距',
   'settings.measure': '行宽',
+  'settings.auto': '自动',
   'settings.justify': '两端对齐',
   'settings.scrollProgress': '滚动进度条',
   'settings.christmas': '圣诞特效',

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,6 +24,7 @@ import SearchPortal from '@components/layout/SearchPortal.astro';
 import CodeBlockFullscreen from '@components/markdown/CodeBlockFullscreen';
 import DiagramFullscreen from '@components/markdown/DiagramFullscreen';
 import ImageLightbox from '@components/markdown/ImageLightbox';
+import SettingsPanel from '@components/settings/SettingsPanel';
 import { Toaster } from '@components/ui/sonner';
 import { bgmConfig, christmasConfig, seoConfig, siteConfig } from '@constants/site-config';
 import { getOgImageUrl } from '@lib/seo/og-image';
@@ -184,6 +185,48 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
         var stored = localStorage.getItem('christmas-enabled');
         var enabled = stored !== 'false'; // 默认启用
         document.documentElement.classList.toggle('christmas', enabled);
+      })();
+    </script>
+
+    <script is:inline>
+      // Apply settings immediately to prevent a flash of default reader styles.
+      // Defaults and localStorage keys must stay in sync with src/store/settings.ts.
+      (function () {
+        function readPositiveNumber(key, fallback) {
+          var stored = parseFloat(localStorage.getItem(key));
+          return isFinite(stored) && stored > 0 ? stored : fallback;
+        }
+        function readBoolean(key, fallback) {
+          var stored = localStorage.getItem(key);
+          return stored === null ? fallback : stored === 'true';
+        }
+        function applySettings() {
+          var root = document.documentElement;
+          var preset = localStorage.getItem('reader-font-preset') || 'round';
+          root.setAttribute('data-font-preset', preset);
+          var fontSize = readPositiveNumber('reader-font-size', 16);
+          root.style.setProperty('--reader-font-size', fontSize + 'px');
+          root.style.setProperty('--reader-line-height', String(readPositiveNumber('reader-line-height', 1.8)));
+          // Convert ch to px so headings and body text share one absolute content width.
+          root.style.setProperty('--reader-measure', readPositiveNumber('reader-measure', 65) * 0.5 * fontSize + 'px');
+          root.classList.toggle('reader-justify', readBoolean('reader-justify', false));
+          root.classList.toggle('motion-off', readBoolean('site-master-motion', false));
+          root.classList.toggle('wave-off', !readBoolean('site-wave', true));
+          // Load WenKai only when the matching preset is selected.
+          if (preset === 'wenkai' && !document.getElementById('lxgw-wenkai-webfont')) {
+            var link = document.createElement('link');
+            link.id = 'lxgw-wenkai-webfont';
+            link.rel = 'stylesheet';
+            link.href = 'https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@1.7.0/style.css';
+            document.head.appendChild(link);
+          }
+        }
+
+        // Apply before the first frame.
+        applySettings();
+
+        // Reapply before Astro renders the swapped page.
+        document.addEventListener('astro:after-swap', applySettings);
       })();
     </script>
 
@@ -353,6 +396,7 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
         </div>
       )}
       <FloatingGroup client:only="react" />
+      <SettingsPanel client:only="react" />
       <MobileDrawer type={siderType} post={post} />
       <SearchDialog client:idle />
       <SearchPortal />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -242,6 +242,26 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
       })();
     </script>
 
+    <noscript>
+      <style is:inline>
+        /* Long code blocks ship pre-collapsed; without JS the toolbar never hydrates, so force them open. */
+        html .prose .code-block-wrapper.code-collapsed > pre {
+          grid-template-rows: 1fr;
+          border-width: 1px;
+          border-radius: 0.75rem;
+          box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+        }
+        html .prose .code-block-wrapper.code-collapsed > pre > code {
+          overflow-x: auto;
+          overflow-y: visible;
+          padding-block: 1rem;
+        }
+        html .prose .code-block-wrapper.code-collapsed > .code-block-wrapper-toolbar-mount {
+          display: none;
+        }
+      </style>
+    </noscript>
+
     <!-- 子页面可通过 slot="head" 注入额外的 head 内容（如 JSON-LD） -->
     <slot name="head" />
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -207,6 +207,10 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
           var stored = parseFloat(localStorage.getItem(key));
           return isFinite(stored) && stored > 0 ? stored : fallback;
         }
+        function readOptionalPositiveNumber(key) {
+          var stored = parseFloat(localStorage.getItem(key));
+          return isFinite(stored) && stored > 0 ? stored : null;
+        }
         function readBoolean(key, fallback) {
           var stored = localStorage.getItem(key);
           return stored === null ? fallback : stored === 'true';
@@ -219,8 +223,13 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
           var fontSize = readPositiveNumber(STORAGE_KEYS.fontSize, READER_DEFAULTS.fontSize);
           root.style.setProperty('--reader-font-size', fontSize + 'px');
           root.style.setProperty('--reader-line-height', String(readPositiveNumber(STORAGE_KEYS.lineHeight, READER_DEFAULTS.lineHeight)));
-          // Convert ch to px so headings and body text share one absolute content width.
-          root.style.setProperty('--reader-measure', readPositiveNumber(STORAGE_KEYS.measure, READER_DEFAULTS.measure) * 0.5 * fontSize + 'px');
+          var measure = readOptionalPositiveNumber(STORAGE_KEYS.measure);
+          if (measure === null) {
+            root.style.removeProperty('--reader-measure');
+          } else {
+            // Convert ch to px so headings and body text share one absolute content width.
+            root.style.setProperty('--reader-measure', measure * 0.5 * fontSize + 'px');
+          }
           root.classList.toggle('reader-justify', readBoolean(STORAGE_KEYS.justify, READER_DEFAULTS.justify));
           root.classList.toggle('motion-off', readBoolean(STORAGE_KEYS.masterMotion, GENERAL_DEFAULTS.masterMotion));
           root.classList.toggle('wave-off', !readBoolean(STORAGE_KEYS.wave, GENERAL_DEFAULTS.wave));

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,6 +28,14 @@ import SettingsPanel from '@components/settings/SettingsPanel';
 import { Toaster } from '@components/ui/sonner';
 import { bgmConfig, christmasConfig, seoConfig, siteConfig } from '@constants/site-config';
 import { getOgImageUrl } from '@lib/seo/og-image';
+import {
+  FONT_PRESETS,
+  GENERAL_DEFAULTS,
+  READER_DEFAULTS,
+  STORAGE_KEYS,
+  WENKAI_STYLESHEET_HREF,
+  WENKAI_STYLESHEET_ID,
+} from '@store/settings-constants';
 import LoadingIndicator from 'astro-loading-indicator/component';
 import { SEO } from 'astro-seo';
 import { Tooltips } from 'astro-tooltips';
@@ -188,9 +196,12 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
       })();
     </script>
 
-    <script is:inline>
+    <script
+      is:inline
+      define:vars={{ STORAGE_KEYS, READER_DEFAULTS, GENERAL_DEFAULTS, FONT_PRESETS, WENKAI_STYLESHEET_ID, WENKAI_STYLESHEET_HREF }}
+    >
       // Apply settings immediately to prevent a flash of default reader styles.
-      // Defaults and localStorage keys must stay in sync with src/store/settings.ts.
+      // Defaults and keys are injected from src/store/settings-constants.ts (single source of truth).
       (function () {
         function readPositiveNumber(key, fallback) {
           var stored = parseFloat(localStorage.getItem(key));
@@ -202,22 +213,23 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
         }
         function applySettings() {
           var root = document.documentElement;
-          var preset = localStorage.getItem('reader-font-preset') || 'round';
+          var stored = localStorage.getItem(STORAGE_KEYS.fontPreset);
+          var preset = FONT_PRESETS.indexOf(stored) !== -1 ? stored : READER_DEFAULTS.fontPreset;
           root.setAttribute('data-font-preset', preset);
-          var fontSize = readPositiveNumber('reader-font-size', 16);
+          var fontSize = readPositiveNumber(STORAGE_KEYS.fontSize, READER_DEFAULTS.fontSize);
           root.style.setProperty('--reader-font-size', fontSize + 'px');
-          root.style.setProperty('--reader-line-height', String(readPositiveNumber('reader-line-height', 1.8)));
+          root.style.setProperty('--reader-line-height', String(readPositiveNumber(STORAGE_KEYS.lineHeight, READER_DEFAULTS.lineHeight)));
           // Convert ch to px so headings and body text share one absolute content width.
-          root.style.setProperty('--reader-measure', readPositiveNumber('reader-measure', 65) * 0.5 * fontSize + 'px');
-          root.classList.toggle('reader-justify', readBoolean('reader-justify', false));
-          root.classList.toggle('motion-off', readBoolean('site-master-motion', false));
-          root.classList.toggle('wave-off', !readBoolean('site-wave', true));
+          root.style.setProperty('--reader-measure', readPositiveNumber(STORAGE_KEYS.measure, READER_DEFAULTS.measure) * 0.5 * fontSize + 'px');
+          root.classList.toggle('reader-justify', readBoolean(STORAGE_KEYS.justify, READER_DEFAULTS.justify));
+          root.classList.toggle('motion-off', readBoolean(STORAGE_KEYS.masterMotion, GENERAL_DEFAULTS.masterMotion));
+          root.classList.toggle('wave-off', !readBoolean(STORAGE_KEYS.wave, GENERAL_DEFAULTS.wave));
           // Load WenKai only when the matching preset is selected.
-          if (preset === 'wenkai' && !document.getElementById('lxgw-wenkai-webfont')) {
+          if (preset === 'wenkai' && !document.getElementById(WENKAI_STYLESHEET_ID)) {
             var link = document.createElement('link');
-            link.id = 'lxgw-wenkai-webfont';
+            link.id = WENKAI_STYLESHEET_ID;
             link.rel = 'stylesheet';
-            link.href = 'https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@1.7.0/style.css';
+            link.href = WENKAI_STYLESHEET_HREF;
             document.head.appendChild(link);
           }
         }
@@ -396,7 +408,7 @@ const keywords = keywordsOverride || siteConfig.keywords || [siteConfig.title];
         </div>
       )}
       <FloatingGroup client:only="react" />
-      <SettingsPanel client:only="react" />
+      <SettingsPanel client:idle />
       <MobileDrawer type={siderType} post={post} />
       <SearchDialog client:idle />
       <SearchPortal />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -26,7 +26,7 @@ const showComments = frontmatter.comments ?? true;
     <Cover slot="cover" title={frontmatter.coverTitle ?? frontmatter.title} />
     <HomeSider slot="sider" />
     <div class={`shadow-box bg-gradient-start mx-0 flex w-full flex-col gap-8 ${CONTENT_PADDING.standard}`}>
-      <div class="prose md:prose-sm dark:prose-invert" data-pagefind-body>
+      <div class="prose dark:prose-invert" data-pagefind-body>
         <CustomContent>
           <slot />
         </CustomContent>

--- a/src/lib/content-enhancer-utils.ts
+++ b/src/lib/content-enhancer-utils.ts
@@ -48,6 +48,11 @@ export function isInfographicBlock(preElement: HTMLElement): boolean {
  * Used by ContentEnhancer to create portal targets.
  */
 export function wrapElement(preElement: HTMLElement, wrapperClass: string): HTMLDivElement {
+  const existingWrapper = preElement.parentElement;
+  if (existingWrapper?.classList.contains(wrapperClass)) {
+    return existingWrapper as HTMLDivElement;
+  }
+
   const wrapper = document.createElement('div');
   wrapper.className = wrapperClass;
 

--- a/src/lib/markdown/shiki-collapsible-transformer.ts
+++ b/src/lib/markdown/shiki-collapsible-transformer.ts
@@ -1,0 +1,35 @@
+import type { Element } from 'hast';
+import type { ShikiTransformer } from 'shiki';
+import { COLLAPSE_LINE_THRESHOLD } from '../../constants/code-block';
+
+/** Wrap long highlighted blocks before HTML serialization so they are collapsed on first paint. */
+export function collapsibleCodeTransformer(): ShikiTransformer {
+  return {
+    name: 'collapsible-code',
+    root(root) {
+      if (this.pre.tagName !== 'pre') return;
+      if (this.source.trimStart().startsWith('infographic ')) return;
+      if (this.source.replace(/\n$/, '').split('\n').length <= COLLAPSE_LINE_THRESHOLD) return;
+
+      const preIndex = root.children.indexOf(this.pre);
+      if (preIndex === -1) return;
+
+      const wrapper: Element = {
+        type: 'element',
+        tagName: 'div',
+        properties: { class: 'code-block-wrapper code-collapsible code-collapsed' },
+        children: [
+          {
+            type: 'element',
+            tagName: 'div',
+            properties: { class: 'code-block-wrapper-toolbar-mount' },
+            children: [],
+          },
+          this.pre,
+        ],
+      };
+
+      root.children[preIndex] = wrapper;
+    },
+  };
+}

--- a/src/pages/post/[...slug].astro
+++ b/src/pages/post/[...slug].astro
@@ -203,7 +203,7 @@ if (post.data.description) {
           <SummaryPanel client:visible summary={summaryText} source={summarySource} className="mt-2" />
         )
       }
-      <article class="prose md:prose-sm dark:prose-invert" data-pagefind-body>
+      <article class="prose dark:prose-invert" data-pagefind-body>
         <CustomContent Content={Content} />
       </article>
       <Comment />

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -44,7 +44,7 @@ export interface ImageLightboxData {
   currentIndex: number;
 }
 
-export type ModalType = 'drawer' | 'search' | 'codeFullscreen' | 'diagramFullscreen' | 'imageLightbox' | null;
+export type ModalType = 'drawer' | 'search' | 'codeFullscreen' | 'diagramFullscreen' | 'imageLightbox' | 'settings' | null;
 
 export interface ModalState {
   type: ModalType;
@@ -69,6 +69,7 @@ export const $imageLightboxData = computed($activeModal, (m) =>
   m.type === 'imageLightbox' ? (m.data as ImageLightboxData) : null,
 );
 export const $isAnyModalOpen = computed($activeModal, (m) => m.type !== null);
+export const $isSettingsOpen = computed($activeModal, (m) => m.type === 'settings');
 
 /**
  * Open a modal with optional data
@@ -84,8 +85,9 @@ export function openModal<T extends ModalType>(
         : never,
 ): void {
   $activeModal.set({ type, data });
-  if (type && typeof document !== 'undefined') {
-    document.body.style.overflow = 'hidden';
+  // Settings stays non-modal, so switching from another modal must release its scroll lock.
+  if (typeof document !== 'undefined') {
+    document.body.style.overflow = type && type !== 'settings' ? 'hidden' : '';
   }
 }
 
@@ -118,6 +120,8 @@ export const toggleDrawer = () => toggleModal('drawer');
 export const openSearch = () => openModal('search');
 export const closeSearch = () => closeModal();
 export const toggleSearch = () => toggleModal('search');
+
+export const toggleSettings = () => toggleModal('settings');
 
 export const openCodeFullscreen = (data: CodeBlockData) => openModal('codeFullscreen', data);
 export const closeCodeFullscreen = () => closeModal();

--- a/src/store/settings-constants.ts
+++ b/src/store/settings-constants.ts
@@ -1,0 +1,41 @@
+/**
+ * Settings defaults, localStorage keys, and WenKai font metadata.
+ *
+ * Single source of truth shared by the settings store and the FOUC-prevention script in
+ * Layout.astro. Kept free of nanostores so Layout.astro can import it at build time without
+ * pulling store side effects into the SSR bundle.
+ */
+
+export const FONT_PRESETS = ['round', 'system', 'serif', 'wenkai'] as const;
+export type FontPreset = (typeof FONT_PRESETS)[number];
+
+export const READER_DEFAULTS = {
+  fontPreset: 'round' as FontPreset,
+  fontSize: 16,
+  lineHeight: 1.8,
+  measure: 65,
+  justify: false,
+};
+
+export const GENERAL_DEFAULTS = {
+  scrollProgress: true,
+  bgmWidget: true,
+  masterMotion: false,
+  wave: true,
+};
+
+export const STORAGE_KEYS = {
+  fontPreset: 'reader-font-preset',
+  fontSize: 'reader-font-size',
+  lineHeight: 'reader-line-height',
+  measure: 'reader-measure',
+  justify: 'reader-justify',
+  scrollProgress: 'site-scroll-progress',
+  bgmWidget: 'site-bgm-widget',
+  masterMotion: 'site-master-motion',
+  wave: 'site-wave',
+} as const;
+
+/** WenKai WebFont loaded on demand from jsDelivr; see docs/adr/0003. */
+export const WENKAI_STYLESHEET_ID = 'lxgw-wenkai-webfont';
+export const WENKAI_STYLESHEET_HREF = 'https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@1.7.0/style.css';

--- a/src/store/settings-constants.ts
+++ b/src/store/settings-constants.ts
@@ -13,9 +13,12 @@ export const READER_DEFAULTS = {
   fontPreset: 'round' as FontPreset,
   fontSize: 16,
   lineHeight: 1.8,
-  measure: 65,
+  measure: null as number | null,
   justify: false,
 };
+
+/** Starting point when the user leaves automatic width through the stepper. */
+export const READER_CUSTOM_MEASURE = 65;
 
 export const GENERAL_DEFAULTS = {
   scrollProgress: true,

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -24,7 +24,7 @@ export type { FontPreset };
 export const readerFontPreset = atom<FontPreset>(READER_DEFAULTS.fontPreset);
 export const readerFontSize = atom<number>(READER_DEFAULTS.fontSize);
 export const readerLineHeight = atom<number>(READER_DEFAULTS.lineHeight);
-export const readerMeasure = atom<number>(READER_DEFAULTS.measure);
+export const readerMeasure = atom<number | null>(READER_DEFAULTS.measure);
 export const readerJustify = atom<boolean>(READER_DEFAULTS.justify);
 
 // General preferences
@@ -55,8 +55,13 @@ function applyReaderPreferences(): void {
   const fontSize = readerFontSize.get();
   root.style.setProperty('--reader-font-size', `${fontSize}px`);
   root.style.setProperty('--reader-line-height', String(readerLineHeight.get()));
-  // Convert ch to px so headings and body text share one absolute content width.
-  root.style.setProperty('--reader-measure', `${readerMeasure.get() * 0.5 * fontSize}px`);
+  const measure = readerMeasure.get();
+  if (measure === null) {
+    root.style.removeProperty('--reader-measure');
+  } else {
+    // Convert ch to px so headings and body text share one absolute content width.
+    root.style.setProperty('--reader-measure', `${measure * 0.5 * fontSize}px`);
+  }
   root.dataset.fontPreset = readerFontPreset.get();
   root.classList.toggle('reader-justify', readerJustify.get());
 }
@@ -100,7 +105,13 @@ export function setLineHeight(multiple: number): void {
   applyReaderPreferences();
 }
 
-export function setMeasure(ch: number): void {
+export function setMeasure(ch: number | null): void {
+  if (ch === null) {
+    readerMeasure.set(null);
+    if (typeof localStorage !== 'undefined') localStorage.removeItem(STORAGE_KEYS.measure);
+    applyReaderPreferences();
+    return;
+  }
   if (!Number.isFinite(ch) || ch <= 0) return;
   readerMeasure.set(ch);
   persist(STORAGE_KEYS.measure, String(ch));
@@ -156,6 +167,11 @@ function readPositiveNumber(key: string, fallback: number): number {
   return Number.isFinite(stored) && stored > 0 ? stored : fallback;
 }
 
+function readOptionalPositiveNumber(key: string): number | null {
+  const stored = Number.parseFloat(localStorage.getItem(key) ?? '');
+  return Number.isFinite(stored) && stored > 0 ? stored : null;
+}
+
 function readBoolean(key: string, fallback: boolean): boolean {
   const stored = localStorage.getItem(key);
   return stored === null ? fallback : stored === 'true';
@@ -174,7 +190,7 @@ export function initSettings(): void {
   }
   readerFontSize.set(readPositiveNumber(STORAGE_KEYS.fontSize, READER_DEFAULTS.fontSize));
   readerLineHeight.set(readPositiveNumber(STORAGE_KEYS.lineHeight, READER_DEFAULTS.lineHeight));
-  readerMeasure.set(readPositiveNumber(STORAGE_KEYS.measure, READER_DEFAULTS.measure));
+  readerMeasure.set(readOptionalPositiveNumber(STORAGE_KEYS.measure));
   readerJustify.set(readBoolean(STORAGE_KEYS.justify, READER_DEFAULTS.justify));
 
   scrollProgressEnabled.set(readBoolean(STORAGE_KEYS.scrollProgress, GENERAL_DEFAULTS.scrollProgress));

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -7,6 +7,7 @@
  */
 
 import { atom } from 'nanostores';
+import { closeBgmPanel } from './bgm';
 import {
   FONT_PRESETS,
   type FontPreset,
@@ -133,6 +134,7 @@ export function setScrollProgressEnabled(enabled: boolean): void {
 export function setBgmWidgetEnabled(enabled: boolean): void {
   bgmWidgetEnabled.set(enabled);
   persist(STORAGE_KEYS.bgmWidget, String(enabled));
+  if (!enabled) closeBgmPanel();
 }
 
 export function setMasterMotionEnabled(enabled: boolean): void {

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -3,45 +3,21 @@
  *
  * Nanostores-based state for reader and general preferences.
  * Preferences persist in localStorage and sync to documentElement through CSS variables,
- * data attributes, and classes.
- *
- * Defaults and localStorage keys must stay in sync with the FOUC-prevention script in Layout.astro.
+ * data attributes, and classes. Defaults and keys live in ./settings-constants.
  */
 
 import { atom } from 'nanostores';
+import {
+  FONT_PRESETS,
+  type FontPreset,
+  GENERAL_DEFAULTS,
+  READER_DEFAULTS,
+  STORAGE_KEYS,
+  WENKAI_STYLESHEET_HREF,
+  WENKAI_STYLESHEET_ID,
+} from './settings-constants';
 
-export type FontPreset = 'round' | 'system' | 'serif' | 'wenkai';
-
-export const READER_DEFAULTS = {
-  fontPreset: 'round' as FontPreset,
-  fontSize: 16,
-  lineHeight: 1.8,
-  measure: 65,
-  justify: false,
-};
-
-export const GENERAL_DEFAULTS = {
-  scrollProgress: true,
-  bgmWidget: true,
-  masterMotion: false,
-  wave: true,
-};
-
-const STORAGE_KEYS = {
-  fontPreset: 'reader-font-preset',
-  fontSize: 'reader-font-size',
-  lineHeight: 'reader-line-height',
-  measure: 'reader-measure',
-  justify: 'reader-justify',
-  scrollProgress: 'site-scroll-progress',
-  bgmWidget: 'site-bgm-widget',
-  masterMotion: 'site-master-motion',
-  wave: 'site-wave',
-} as const;
-
-/** WenKai WebFont loaded on demand from jsDelivr; see docs/adr/0003. */
-const WENKAI_STYLESHEET_ID = 'lxgw-wenkai-webfont';
-const WENKAI_STYLESHEET_HREF = 'https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@1.7.0/style.css';
+export type { FontPreset };
 
 // Reader preferences
 export const readerFontPreset = atom<FontPreset>(READER_DEFAULTS.fontPreset);
@@ -184,19 +160,14 @@ function readBoolean(key: string, fallback: boolean): boolean {
 }
 
 /**
- * Initialize settings state from localStorage
- * Should be called on client-side only
- *
- * Default values (must match Layout.astro FOUC prevention script):
- * - fontPreset: 'round', fontSize: 16, lineHeight: 1.8, measure: 65, justify: false
- * - scrollProgress: true, bgmWidget: true, masterMotion: false, wave: true
+ * Initialize settings state from localStorage. Client-side only.
  */
 export function initSettings(): void {
   if (typeof window === 'undefined') return;
 
   const storedPreset = localStorage.getItem(STORAGE_KEYS.fontPreset);
-  if (storedPreset === 'round' || storedPreset === 'system' || storedPreset === 'serif' || storedPreset === 'wenkai') {
-    readerFontPreset.set(storedPreset);
+  if (storedPreset && FONT_PRESETS.includes(storedPreset as FontPreset)) {
+    readerFontPreset.set(storedPreset as FontPreset);
     if (storedPreset === 'wenkai') loadWenkaiFont();
   }
   readerFontSize.set(readPositiveNumber(STORAGE_KEYS.fontSize, READER_DEFAULTS.fontSize));

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,0 +1,214 @@
+/**
+ * Settings Center State Management
+ *
+ * Nanostores-based state for reader and general preferences.
+ * Preferences persist in localStorage and sync to documentElement through CSS variables,
+ * data attributes, and classes.
+ *
+ * Defaults and localStorage keys must stay in sync with the FOUC-prevention script in Layout.astro.
+ */
+
+import { atom } from 'nanostores';
+
+export type FontPreset = 'round' | 'system' | 'serif' | 'wenkai';
+
+export const READER_DEFAULTS = {
+  fontPreset: 'round' as FontPreset,
+  fontSize: 16,
+  lineHeight: 1.8,
+  measure: 65,
+  justify: false,
+};
+
+export const GENERAL_DEFAULTS = {
+  scrollProgress: true,
+  bgmWidget: true,
+  masterMotion: false,
+  wave: true,
+};
+
+const STORAGE_KEYS = {
+  fontPreset: 'reader-font-preset',
+  fontSize: 'reader-font-size',
+  lineHeight: 'reader-line-height',
+  measure: 'reader-measure',
+  justify: 'reader-justify',
+  scrollProgress: 'site-scroll-progress',
+  bgmWidget: 'site-bgm-widget',
+  masterMotion: 'site-master-motion',
+  wave: 'site-wave',
+} as const;
+
+/** WenKai WebFont loaded on demand from jsDelivr; see docs/adr/0003. */
+const WENKAI_STYLESHEET_ID = 'lxgw-wenkai-webfont';
+const WENKAI_STYLESHEET_HREF = 'https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@1.7.0/style.css';
+
+// Reader preferences
+export const readerFontPreset = atom<FontPreset>(READER_DEFAULTS.fontPreset);
+export const readerFontSize = atom<number>(READER_DEFAULTS.fontSize);
+export const readerLineHeight = atom<number>(READER_DEFAULTS.lineHeight);
+export const readerMeasure = atom<number>(READER_DEFAULTS.measure);
+export const readerJustify = atom<boolean>(READER_DEFAULTS.justify);
+
+// General preferences
+export const scrollProgressEnabled = atom<boolean>(GENERAL_DEFAULTS.scrollProgress);
+export const bgmWidgetEnabled = atom<boolean>(GENERAL_DEFAULTS.bgmWidget);
+export const masterMotionEnabled = atom<boolean>(GENERAL_DEFAULTS.masterMotion);
+export const waveEnabled = atom<boolean>(GENERAL_DEFAULTS.wave);
+
+/**
+ * Insert the WenKai stylesheet once when that preset is first selected.
+ */
+function loadWenkaiFont(): void {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(WENKAI_STYLESHEET_ID)) return;
+  const link = document.createElement('link');
+  link.id = WENKAI_STYLESHEET_ID;
+  link.rel = 'stylesheet';
+  link.href = WENKAI_STYLESHEET_HREF;
+  document.head.appendChild(link);
+}
+
+/**
+ * Synchronize reader preferences to documentElement.
+ */
+function applyReaderPreferences(): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  const fontSize = readerFontSize.get();
+  root.style.setProperty('--reader-font-size', `${fontSize}px`);
+  root.style.setProperty('--reader-line-height', String(readerLineHeight.get()));
+  // Convert ch to px so headings and body text share one absolute content width.
+  root.style.setProperty('--reader-measure', `${readerMeasure.get() * 0.5 * fontSize}px`);
+  root.dataset.fontPreset = readerFontPreset.get();
+  root.classList.toggle('reader-justify', readerJustify.get());
+}
+
+/**
+ * Synchronize general preferences to documentElement classes.
+ */
+function applyGeneralPreferences(): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.classList.toggle('motion-off', masterMotionEnabled.get());
+  root.classList.toggle('wave-off', !waveEnabled.get());
+}
+
+function persist(key: string, value: string): void {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(key, value);
+  }
+}
+
+// Reader preference setters
+
+export function setFontPreset(preset: FontPreset): void {
+  readerFontPreset.set(preset);
+  persist(STORAGE_KEYS.fontPreset, preset);
+  if (preset === 'wenkai') loadWenkaiFont();
+  applyReaderPreferences();
+}
+
+export function setFontSize(px: number): void {
+  if (!Number.isFinite(px) || px <= 0) return;
+  readerFontSize.set(px);
+  persist(STORAGE_KEYS.fontSize, String(px));
+  applyReaderPreferences();
+}
+
+export function setLineHeight(multiple: number): void {
+  if (!Number.isFinite(multiple) || multiple <= 0) return;
+  readerLineHeight.set(multiple);
+  persist(STORAGE_KEYS.lineHeight, String(multiple));
+  applyReaderPreferences();
+}
+
+export function setMeasure(ch: number): void {
+  if (!Number.isFinite(ch) || ch <= 0) return;
+  readerMeasure.set(ch);
+  persist(STORAGE_KEYS.measure, String(ch));
+  applyReaderPreferences();
+}
+
+export function setJustify(enabled: boolean): void {
+  readerJustify.set(enabled);
+  persist(STORAGE_KEYS.justify, String(enabled));
+  applyReaderPreferences();
+}
+
+/**
+ * Restore reader defaults without changing general preferences.
+ */
+export function resetReaderPreferences(): void {
+  setFontPreset(READER_DEFAULTS.fontPreset);
+  setFontSize(READER_DEFAULTS.fontSize);
+  setLineHeight(READER_DEFAULTS.lineHeight);
+  setMeasure(READER_DEFAULTS.measure);
+  setJustify(READER_DEFAULTS.justify);
+}
+
+// General preference setters
+
+export function setScrollProgressEnabled(enabled: boolean): void {
+  scrollProgressEnabled.set(enabled);
+  persist(STORAGE_KEYS.scrollProgress, String(enabled));
+}
+
+export function setBgmWidgetEnabled(enabled: boolean): void {
+  bgmWidgetEnabled.set(enabled);
+  persist(STORAGE_KEYS.bgmWidget, String(enabled));
+}
+
+export function setMasterMotionEnabled(enabled: boolean): void {
+  masterMotionEnabled.set(enabled);
+  persist(STORAGE_KEYS.masterMotion, String(enabled));
+  applyGeneralPreferences();
+}
+
+export function setWaveEnabled(enabled: boolean): void {
+  waveEnabled.set(enabled);
+  persist(STORAGE_KEYS.wave, String(enabled));
+  applyGeneralPreferences();
+}
+
+// Initialization
+
+function readPositiveNumber(key: string, fallback: number): number {
+  const stored = Number.parseFloat(localStorage.getItem(key) ?? '');
+  return Number.isFinite(stored) && stored > 0 ? stored : fallback;
+}
+
+function readBoolean(key: string, fallback: boolean): boolean {
+  const stored = localStorage.getItem(key);
+  return stored === null ? fallback : stored === 'true';
+}
+
+/**
+ * Initialize settings state from localStorage
+ * Should be called on client-side only
+ *
+ * Default values (must match Layout.astro FOUC prevention script):
+ * - fontPreset: 'round', fontSize: 16, lineHeight: 1.8, measure: 65, justify: false
+ * - scrollProgress: true, bgmWidget: true, masterMotion: false, wave: true
+ */
+export function initSettings(): void {
+  if (typeof window === 'undefined') return;
+
+  const storedPreset = localStorage.getItem(STORAGE_KEYS.fontPreset);
+  if (storedPreset === 'round' || storedPreset === 'system' || storedPreset === 'serif' || storedPreset === 'wenkai') {
+    readerFontPreset.set(storedPreset);
+    if (storedPreset === 'wenkai') loadWenkaiFont();
+  }
+  readerFontSize.set(readPositiveNumber(STORAGE_KEYS.fontSize, READER_DEFAULTS.fontSize));
+  readerLineHeight.set(readPositiveNumber(STORAGE_KEYS.lineHeight, READER_DEFAULTS.lineHeight));
+  readerMeasure.set(readPositiveNumber(STORAGE_KEYS.measure, READER_DEFAULTS.measure));
+  readerJustify.set(readBoolean(STORAGE_KEYS.justify, READER_DEFAULTS.justify));
+
+  scrollProgressEnabled.set(readBoolean(STORAGE_KEYS.scrollProgress, GENERAL_DEFAULTS.scrollProgress));
+  bgmWidgetEnabled.set(readBoolean(STORAGE_KEYS.bgmWidget, GENERAL_DEFAULTS.bgmWidget));
+  masterMotionEnabled.set(readBoolean(STORAGE_KEYS.masterMotion, GENERAL_DEFAULTS.masterMotion));
+  waveEnabled.set(readBoolean(STORAGE_KEYS.wave, GENERAL_DEFAULTS.wave));
+
+  applyReaderPreferences();
+  applyGeneralPreferences();
+}

--- a/src/styles/components/wave.css
+++ b/src/styles/components/wave.css
@@ -109,3 +109,21 @@
     transform: translate(85px, 0%);
   }
 }
+
+/* Settings Center controls */
+
+/* Hide cover waves when their individual preference is disabled. */
+html.wave-off .wave-wrap {
+  display: none;
+}
+
+/* The master motion preference preserves the wave shape but stops its animation. */
+html.motion-off .wave .parallax > use {
+  animation: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wave .parallax > use {
+    animation: none;
+  }
+}

--- a/src/styles/components/wave.css
+++ b/src/styles/components/wave.css
@@ -119,7 +119,8 @@ html.wave-off .wave-wrap {
 
 /* The master motion preference preserves the wave shape but stops its animation. */
 html.motion-off .wave .parallax > use {
-  animation: none !important;
+  /* html.motion-off … outranks the .wave-wrap-nested source rule, so no !important needed. */
+  animation: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/global/motion.css
+++ b/src/styles/global/motion.css
@@ -13,7 +13,8 @@ html.motion-off .lightrope li,
 html.motion-off .animate-ping,
 html.motion-off .sider-slot.entering,
 html.motion-off .sider-slot.exiting {
-  animation: none !important;
+  /* html.motion-off … outranks the single-class animation definitions, so no !important needed. */
+  animation: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -27,6 +28,7 @@ html.motion-off .sider-slot.exiting {
   .animate-ping,
   .sider-slot.entering,
   .sider-slot.exiting {
+    /* biome-ignore lint/complexity/noImportantStyles: same specificity as the source animations, which are imported after this file, so !important is required to win. */
     animation: none !important;
   }
 }

--- a/src/styles/global/motion.css
+++ b/src/styles/global/motion.css
@@ -1,0 +1,32 @@
+/*
+  The master motion preference disables continuous decorative motion while
+  preserving interaction feedback and loading indicators.
+*/
+
+html.motion-off footer .animate-spin,
+html.motion-off .animate-spin.duration-10000,
+html.motion-off .hover\:animate-shake,
+html.motion-off .rainbow,
+html.motion-off .typewriter-cursor,
+html.motion-off .audio-player-disc,
+html.motion-off .lightrope li,
+html.motion-off .animate-ping,
+html.motion-off .sider-slot.entering,
+html.motion-off .sider-slot.exiting {
+  animation: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  footer .animate-spin,
+  .animate-spin.duration-10000,
+  .hover\:animate-shake,
+  .rainbow,
+  .typewriter-cursor,
+  .audio-player-disc,
+  .lightrope li,
+  .animate-ping,
+  .sider-slot.entering,
+  .sider-slot.exiting {
+    animation: none !important;
+  }
+}

--- a/src/styles/global/tailwind.css
+++ b/src/styles/global/tailwind.css
@@ -40,7 +40,11 @@
   h5,
   h6 {
     font-family: "寒蝉全圆体", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.02em;
+  }
+
+  ::selection {
+    background: hsl(var(--primary) / 0.25);
   }
 
   /* Japanese pages: use Gen Jyuu Gothic P for correct JIS glyphs (fix #113) */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3,6 +3,7 @@
 @import "./theme/theme-transition.css";
 @import "./christmas/christmas-theme.css";
 @import "./global/animate.css";
+@import "./global/motion.css";
 @import "./global/tailwind.css";
 
 @import "./theme/markdown.css";

--- a/src/styles/theme/markdown.css
+++ b/src/styles/theme/markdown.css
@@ -3,12 +3,10 @@
   font-size: var(--reader-font-size, 1rem);
   line-height: var(--reader-line-height, 1.8);
 
-  /* Keep every prose child in one measured column; wide code and tables scroll within it.
-     Explicit width prevents auto margins on this flex item from using max-content width.
-     JavaScript converts the requested ch measure to px so differently sized children share
-     the same absolute width. */
+  /* Preserve the original full-width layout until the reader chooses a custom measure.
+     JavaScript converts that measure to px so differently sized children share one width. */
   width: 100%;
-  max-width: var(--reader-measure, 32.5rem); /* 65ch × 0.5 × 16px */
+  max-width: var(--reader-measure, none);
   margin-inline: auto;
 
   /* Progressive CJK typography enhancements. */

--- a/src/styles/theme/markdown.css
+++ b/src/styles/theme/markdown.css
@@ -342,8 +342,8 @@
     display: block;
     padding: 1rem 1.5rem;
     overflow-x: auto;
-    /* Use em so code follows the reader font-size preference. */
-    font-size: 0.875em;
+    /* The parent pre already carries Typography's relative code scale. */
+    font-size: inherit;
     line-height: 1.7;
     /* 覆盖 Typography 默认值 */
     background-color: transparent;
@@ -378,6 +378,14 @@
   /* Reserve the toolbar row before the idle-hydrated controls mount. */
   .code-block-wrapper.code-collapsed > .code-block-wrapper-toolbar-mount {
     min-height: 2.625rem;
+  }
+
+  /* Toolbar-shaped skeleton until hydration fills the mount (mirrors MacToolbar chrome). */
+  .code-block-wrapper.code-collapsed > .code-block-wrapper-toolbar-mount:empty {
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.75rem;
+    background-color: hsl(var(--muted) / 0.5);
+    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
   }
 
   .code-block-wrapper.code-collapsed .code-block-wrapper-toolbar-mount > div {

--- a/src/styles/theme/markdown.css
+++ b/src/styles/theme/markdown.css
@@ -1,6 +1,21 @@
 .prose {
-  /* override the max-width of the prose */
-  max-width: none;
+  /* Reader variables are set by src/store/settings.ts and the inline Layout.astro script. */
+  font-size: var(--reader-font-size, 1rem);
+  line-height: var(--reader-line-height, 1.8);
+
+  /* Keep every prose child in one measured column; wide code and tables scroll within it.
+     Explicit width prevents auto margins on this flex item from using max-content width.
+     JavaScript converts the requested ch measure to px so differently sized children share
+     the same absolute width. */
+  width: 100%;
+  max-width: var(--reader-measure, 32.5rem); /* 65ch × 0.5 × 16px */
+  margin-inline: auto;
+
+  /* Progressive CJK typography enhancements. */
+  word-break: auto-phrase;
+  line-break: strict;
+  hanging-punctuation: first allow-end;
+  text-spacing-trim: space-start;
 
   a {
     @apply text-primary hover:text-blue no-underline transition-colors duration-300 hover:underline;
@@ -327,11 +342,52 @@
     display: block;
     padding: 1rem 1.5rem;
     overflow-x: auto;
-    font-size: 0.875rem;
+    /* Use em so code follows the reader font-size preference. */
+    font-size: 0.875em;
     line-height: 1.7;
     /* 覆盖 Typography 默认值 */
     background-color: transparent;
     color: inherit;
+  }
+
+  /* Collapsible code blocks; long blocks start collapsed in CodeBlockToolbar. */
+
+  /* The code element needs min-height: 0 for the 0fr row to collapse. */
+  .code-block-wrapper > pre {
+    display: grid;
+    grid-template-rows: 1fr;
+  }
+
+  .code-block-wrapper > pre > code {
+    min-height: 0;
+  }
+
+  /* Remove the body chrome so the toolbar becomes the complete collapsed card. */
+  .code-block-wrapper.code-collapsed > pre {
+    grid-template-rows: 0fr;
+    border-width: 0;
+    box-shadow: none;
+  }
+
+  .code-block-wrapper.code-collapsed > pre > code {
+    overflow: hidden;
+    /* Padding contributes to min-content size and would keep the 0fr row open. */
+    padding-block: 0;
+  }
+
+  .code-block-wrapper.code-collapsed .code-block-wrapper-toolbar-mount > div {
+    border-bottom: 1px solid hsl(var(--border));
+    border-radius: 0.75rem;
+  }
+
+  /* Make the full toolbar a collapse toggle. */
+  .code-block-wrapper.code-collapsible .code-block-wrapper-toolbar-mount > div {
+    cursor: pointer;
+  }
+
+  /* Suppress the first collapse animation; see CodeBlockToolbar. */
+  .code-block-wrapper.code-no-transition > pre {
+    transition: none !important;
   }
 
   /* 移除 pre code 的 Typography ::before/::after */
@@ -351,6 +407,13 @@
 
 .code-block-wrapper {
   margin-bottom: 1.25rem;
+}
+
+/* Animate the row only when the OS motion preference allows it. */
+@media (prefers-reduced-motion: no-preference) {
+  .prose .code-block-wrapper > pre {
+    transition: grid-template-rows 0.3s ease;
+  }
 }
 
 /* 如果第一个子节点就是标题 */
@@ -626,7 +689,7 @@
 .mermaid-source {
   padding: 1rem 1.5rem;
   overflow-x: auto;
-  font-size: 0.875rem;
+  font-size: 0.875em;
   line-height: 1.7;
   font-family: var(--font-mono);
   white-space: pre-wrap;
@@ -673,4 +736,31 @@
   content: attr(data-prompt) " ";
   color: hsl(var(--muted-foreground));
   user-select: none;
+}
+
+/* Reader font presets */
+
+/* The default rounded preset inherits the existing Han Chan and Gen Jyuu rules. */
+/* The system preset preserves Gen Jyuu on Japanese pages. */
+html[data-font-preset="system"]:not(:lang(ja)) .prose,
+html[data-font-preset="system"]:not(:lang(ja)) .prose :is(h1, h2, h3, h4, h5, h6) {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC",
+    sans-serif;
+}
+
+html[data-font-preset="serif"] .prose,
+html[data-font-preset="serif"] .prose :is(h1, h2, h3, h4, h5, h6) {
+  font-family: "Songti SC", "Noto Serif CJK SC", "Noto Serif SC", "Source Han Serif SC", serif;
+}
+
+html[data-font-preset="wenkai"] .prose,
+html[data-font-preset="wenkai"] .prose :is(h1, h2, h3, h4, h5, h6) {
+  font-family: "LXGW WenKai", "LXGW WenKai Screen", "寒蝉全圆体", serif;
+}
+
+/* Reader text justification */
+
+html.reader-justify .prose {
+  text-align: justify;
 }

--- a/src/styles/theme/markdown.css
+++ b/src/styles/theme/markdown.css
@@ -350,7 +350,7 @@
     color: inherit;
   }
 
-  /* Collapsible code blocks; long blocks start collapsed in CodeBlockToolbar. */
+  /* Collapsible code blocks; long blocks are wrapped in their initial state during highlighting. */
 
   /* The code element needs min-height: 0 for the 0fr row to collapse. */
   .code-block-wrapper > pre {
@@ -375,6 +375,11 @@
     padding-block: 0;
   }
 
+  /* Reserve the toolbar row before the idle-hydrated controls mount. */
+  .code-block-wrapper.code-collapsed > .code-block-wrapper-toolbar-mount {
+    min-height: 2.625rem;
+  }
+
   .code-block-wrapper.code-collapsed .code-block-wrapper-toolbar-mount > div {
     border-bottom: 1px solid hsl(var(--border));
     border-radius: 0.75rem;
@@ -383,11 +388,6 @@
   /* Make the full toolbar a collapse toggle. */
   .code-block-wrapper.code-collapsible .code-block-wrapper-toolbar-mount > div {
     cursor: pointer;
-  }
-
-  /* Suppress the first collapse animation; see CodeBlockToolbar. */
-  .code-block-wrapper.code-no-transition > pre {
-    transition: none !important;
   }
 
   /* 移除 pre code 的 Typography ::before/::after */


### PR DESCRIPTION
## Summary

- Add a registry-driven Settings Center with persisted reading and general preferences.
- Apply scroll-progress and reduced-motion preferences consistently across desktop and mobile post indicators.
- Improve article typography and long-code-block behavior while preserving accessible no-JavaScript output.

## User-facing changes

### Reading preferences

- Choose round, system, serif, or WenKai fonts.
- Adjust font size, line height, and content width with debounced numeric controls.
- Toggle text justification and restore reader defaults.
- Use the same reading controls on posts and other prose pages.

### General preferences

- Show or hide scroll progress and the BGM widget.
- Disable continuous decorative motion or cover waves independently.
- Keep progress indicators responsive without spring smoothing when reduced motion is enabled.
- Close the BGM panel immediately when its widget is disabled.

### Reading experience

- Use a more consistent default prose scale, heading spacing, text selection color, and code sizing.
- Collapse long highlighted code blocks in the generated HTML before first paint.
- Reserve toolbar space during idle hydration to avoid layout shifts and expand code automatically when JavaScript is unavailable.
- Keep the settings panel reachable and scrollable on short or landscape viewports.

## Implementation notes

- Persist preferences in `localStorage` and apply reader styles in the document head to avoid FOUC.
- Share defaults and storage keys between the inline boot script and Nanostore state.
- Lazy-load the settings panel body so Floating UI, React Hook Form, and Zod stay out of the first-paint bundle.
- Render controls from a declarative settings registry and provide English, Japanese, and Chinese translations.
- Add `@radix-ui/react-switch` for accessible switch controls.
- No migration is required; invalid or missing stored values fall back to defaults.

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `git diff --check`

All commands pass on the current PR head. Lint/check retain the existing unused-import warning for `getContentCategoryName`; there are no errors. Manual browser interaction was not run in the current environment.
