### PR TITLE
v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-koharu",
   "type": "module",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "packageManager": "pnpm@10.28.2",
   "engines": {
     "node": ">=22.20.0"


### PR DESCRIPTION
## 概要

发布 Astro 7 静态站点升级，并将项目版本提升至 v6.0.0。

## 主要变更

### Features

- 升级到 Astro 7.1.3、Vite 8.1.5 与配套 integrations，继续保持纯静态输出默认值。（#202）
- 迁移到 astro-pagefind 2 / Pagefind Component UI，保留多语言占位文案、键盘导航、主题样式与既有搜索入口。（#202）
- 以本地 Astro 组件替代仅支持到 Astro 6 的 Umami integration，保留现有配置字段与 tracker 行为。（#202）

### Bug Fixes

- 修复 Sonda analysis mode 在 Astro 7 / Vite 8 下的集成方式。（#202）
- 将 Docker 健康检查固定到 IPv4 localhost，与现有 nginx 监听方式一致。（#202）

### Documentation

- 更新中英日文环境要求与 Astro 版本说明，并新增 Astro 7 升级、验证和回滚指南。（#202）

## 验证

- pnpm install --frozen-lockfile
- pnpm lint（458 files，无错误）
- pnpm check（355 files，0 errors / 0 warnings / 0 hints）
- pnpm test:migrate（42/42 通过）
- pnpm build（151 个静态页面；Pagefind 索引 155 页）
- git diff --check

## 影响面

- 这是破坏性主版本升级：最低 Node.js 版本提高到 22.20.0，pnpm 继续固定为 10.28.2。
- 下游若有针对旧 pagefind-ui__* class 的自定义 CSS，需要随 Pagefind Component UI 一并迁移。
- config/site.yaml、Umami 配置字段、文章内容和静态部署入口无需迁移。
- 默认仍输出纯静态 dist/，不启用动态路由或 Node adapter。