### PR TITLE
v6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-koharu",
   "type": "module",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "packageManager": "pnpm@10.28.2",
   "engines": {
     "node": ">=22.20.0"


### PR DESCRIPTION
## 概要

发布 v6.1.0：新增可选的 Koharu Moments 动态归档能力，并提供 astro-koharu、koharu-suite、PostgreSQL 18 与 Caddy 的小白向单机部署基线。

## 主要变更

### Features

- 基于 Astro Live Content Collections 与 `@coszone/koharu-astro` 增加可选的 Moments 集成，支持全局与频道时间线、消息详情、上下文、搜索、分页、媒体展示、源消息跳转、RSS 和多频道配置；默认关闭时继续生成原有静态站点。（#204）
- 增加 Astro Node standalone 动态部署目标、有界内存缓存和故障隔离：koharu-suite 暂时不可用时，动态路由返回受控的 503，博客首页、文章和其他静态内容继续服务。（#204）

### Bug Fixes

- 修复动态生产镜像缺少 `@iconify/react` 与 `transliteration` 的问题。根因是两个运行时模块此前只列在 `devDependencies`，而 Node production stage 只安装生产依赖；现已改为正式依赖。该问题仅影响启用 Moments 的自托管动态镜像，现有静态部署无需调整。（#205）
- 完善 Moments 的单频道、窄屏和无障碍体验，包括时间线、搜索筛选器、标签快捷搜索、媒体状态与移动端操作区域。（#204）

### Documentation

- 新增单机 Compose 部署样例，覆盖 PostgreSQL 18、koharu-suite 0.3.1、Caddy HTTPS、Owner/频道初始化、5 GiB 媒体缓存、验收、排障、备份和升级。（#205）
- 新增中、英、日文 Moments 配置指南、动态部署架构说明与完整设计基线。（#204）

## 验证

- `pnpm lint`
- `pnpm check`
- `pnpm test:moments`（35/35）
- 默认关闭 Moments 的静态 production build
- 启用 Moments、suite 不可达时的动态 production build
- 合成数据的 index、channel、detail、search、RSS、media、cache 与失败路径 smoke
- `docker compose config --quiet`、部署 smoke 脚本语法检查与 Caddy 2.11.4 配置校验
- 动态 Docker 镜像以非 root 用户运行；首页返回 200，suite 不可达时 `/moments` 返回 503 且容器保持健康
- Owner 已完成真实频道链路与部署样例验收
- `pnpm exec biome check package.json`

## 影响面

- 无破坏性变更，现有配置不需要迁移。
- `moments.enabled` 默认关闭；未启用的用户继续使用原有静态构建和部署方式。
- 启用 Moments 后需要可访问的 koharu-suite public origin，并使用 Astro Node standalone 或等价的动态运行环境。
- 本 PR 只将 `package.json` 版本更新到 `6.1.0`；不更新已停止维护的 `CHANGELOG.md`。
