### PR TITLE
fix: group Telegram media albums in Moments

### DIFF
--- a/docs/design/g2.7-moments-integration.md
+++ b/docs/design/g2.7-moments-integration.md
@@ -121,8 +121,8 @@ Astro 6/7 Live Content Collections 允许只在 on-demand route 的请求阶段�
 | 邻接导航 | package 0.2.0 提供同频道 newer/older context；detail 首版交付 |
 | 长消息 | feed 中约 `24rem` 后折叠；详情始终完整 |
 | 编辑状态 | `revision > 1` 只显示“已更新”；不显示伪造编辑时间 |
-| 相册 | 不跨 message 猜测聚合；同一 message 内多 media 仍显示网格 |
-| 媒体加载 | image lazy；video metadata/no autoplay；audio none；feed 最多预览 4 个 |
+| 相册 | 相邻消息按显式 group 或 Desktop 强信号做展示层聚合；cursor 边界保持独立 |
+| 媒体加载 | image lazy；video metadata/no autoplay；audio none；单消息 feed 最多预览 4 个，聚合相册展示全部成员（最多 10 个） |
 | 来源链接 | 文案统一为“查看源消息”；`sourceUrl` 为空时不生成假链接 |
 | 时间 | 使用站点时区的绝对时间和标准 `<time datetime>` |
 | 导航 | 支持 `feature: moments` 占位调序；缺席时默认插入归档之后 |
@@ -552,9 +552,12 @@ sequenceDiagram
 
 Telegram album：
 
-- 不跨多个 message 按 `mediaGroupId` 猜测聚合；
-- 每个 public message 保持独立 card、revision、permalink 和 source link；
-- 只有 suite 提供分页原子的 group contract 后才实现真正 album card。
+- API 仍不创造新的 album entity，每个 public message 保持独立 revision、permalink 和 source link；
+- feed/RSS 对相邻同 `mediaGroupId` 消息做展示层合并；Desktop 历史缺少该字段时，只接受同频道、
+  同时间、连续 Telegram 来源 ID、全员含媒体、最多一条正文的强信号；
+- 相册使用不随 caption 编辑变化的稳定成员 UUID 作为 RSS GUID 锚点；card/RSS link 与正文均跟随含
+  caption 的成员，保证 permalink 详情与所见正文一致。每个媒体保留自己的 source link，feed 展示相册的全部成员；
+- cursor 前后边界候选不合并，避免把尚未加载的相册成员隐藏；分页原子的完整 album contract 仍需 suite 支持。
 
 ### 5.8 Cache 与错误
 
@@ -615,9 +618,9 @@ G2.7 生成：
 规则：
 
 - feed title/description 使用 moments 或 channel 配置；
-- item link 指向 astro-koharu message permalink；
-- GUID 使用稳定 suite message UUID；
-- pubDate 使用 `publishedAt`；
+- item link 指向提供正文的 astro-koharu message permalink；
+- GUID 使用稳定 suite message UUID；相册选用不随 caption 编辑变化的成员 UUID 作为 RSS GUID 锚点；
+- pubDate 使用 RSS GUID 锚点成员的 `publishedAt`；
 - edit 后 GUID/pubDate 不变，正文按 current revision 更新；
 - global feed 使用 `messages.latest()`；
 - channel feed 使用 `messages.list({ channelId })`；
@@ -721,8 +724,8 @@ suite content edit 不需要重新构建。
 | 根级 catch-all | 可处理所有 configurable path | 会成为全站 fallback，风险不可接受 | 不采用 |
 | 直接链接 suite RSS | 无需新 API | item 链接不回博客、品牌不一致 | 不采用 |
 | Astro branded RSS + latest API | canonical 正确、品牌完整 | 需 package 0.2.0 前置 | 采用 |
-| 按 mediaGroupId 前端猜 album | 初看接近 Telegram | cursor 会拆组、caption/permalink 不明确 | 不采用 |
-| 每个 API message 独立 card | 数据语义稳定 | 相册首版不合并 | 采用 |
+| 相邻消息展示层合并 album | 接近 Telegram；兼容 Desktop 历史 | cursor 可能拆组 | 采用强信号并在 cursor 边界退回独立 card |
+| API message 合并成新实体 | 分页可原子化 | 破坏既有 UUID/revision/permalink | 不采用；等待 suite 显式 group contract |
 | message 第一图自动作 OG | 每条分享图不同 | 不可控、媒体可能失效或不适合分享 | 不采用 |
 | 配置 OG + resolver | 可控、未来可替换 | 第一版不是每条都独特 | 采用 |
 | Astro 7 与 G2.7 同 PR | 一次升级完成 | Pagefind/Umami/Vite 风险混入新功能 | 不采用 |
@@ -786,7 +789,7 @@ suite content edit 不需要重新构建。
 | username fallback 变化 | 旧 channel URL 失效 | 文档建议生产配置稳定 slug |
 | transparent stale | 页面不知道 cache 是否在返回旧响应 | 不伪造实时状态；只承诺已验证 provider 的语义 |
 | media 404/tombstone | broken player/image | client fallback 到 unavailable state |
-| album 跨 cursor | 错误合并或重复 | 首版每 message 独立 card |
+| album 跨 cursor | 错误合并或隐藏成员 | cursor 前后边界候选保持独立 card |
 | package peer 放宽未实测 | Astro 7 runtime regressions | Astro 6/7 双 fixture |
 
 ## 9. 上线与回滚（Rollout & Migration）

--- a/docs/features/moments.en.md
+++ b/docs/features/moments.en.md
@@ -81,11 +81,16 @@ It is one canonical dynamic area and is not duplicated under `/en` or `/ja`. Tel
 links use “View source message”; no fake source link is rendered when the public Telegram URL is unavailable.
 
 Messages are newest-first. Long feed text is collapsed only after JavaScript confirms overflow; detail pages always
-show the full body. `revision > 1` means only “Updated” because no reliable edit timestamp exists. Each suite message
-remains independent; the first release does not guess cross-message albums from Telegram `mediaGroupId`.
+show the full body. `revision > 1` means only “Updated” because no reliable edit timestamp exists. Adjacent messages
+with the same `mediaGroupId` share one album card. When Telegram Desktop JSON omits that field, Moments coalesces
+only same-channel messages with one timestamp, consecutive source IDs, media on every member, and at most one
+caption. Candidates touching a cursor boundary remain separate so unloaded media is never hidden; every suite UUID
+and detail permalink remains valid. Album cards render every member, and each attachment keeps its own source link.
 
-RSS uses the stable suite message UUID as GUID and the original `publishedAt` as `pubDate`. Editing updates the body
-but never changes the GUID or publication date.
+RSS uses the stable suite message UUID as GUID and that stable member's original `publishedAt` as `pubDate`; an album
+selects a member UUID independent of caption edits as its RSS GUID anchor. The album card and RSS item link instead
+follow the member that supplies the body, so the opened detail matches the displayed caption. Editing updates the body
+without changing the GUID or publication date.
 
 ## Cache and failure boundaries
 

--- a/docs/features/moments.ja.md
+++ b/docs/features/moments.ja.md
@@ -80,11 +80,16 @@ navigation:
 見る」と表示し、公開 URL を作れない場合は偽のリンクを出しません。
 
 新しい順に表示します。フィードの長文は JavaScript が実際のオーバーフローを確認した後だけ折りたたみ、詳細では
-常に全文を表示します。`revision > 1` は「更新済み」だけを示し、編集日時を推測しません。suite message は 1 件ずつ
-独立し、初版では Telegram `mediaGroupId` から複数メッセージのアルバムを推測しません。
+常に全文を表示します。`revision > 1` は「更新済み」だけを示し、編集日時を推測しません。同じ `mediaGroupId` を持つ
+隣接メッセージは 1 枚のアルバムカードにまとめます。Telegram Desktop JSON にこの値がない場合は、同一チャンネル、
+同一時刻、連続する出典 ID、全項目にメディアがあり本文は最大 1 件、という条件をすべて満たす場合だけまとめます。
+cursor 境界の候補は分離したままにし、各 suite UUID と詳細 permalink は引き続き有効です。
+アルバムカードは全メディアを表示し、各項目はそれぞれの出典リンクを保持します。
 
-RSS GUID は安定した suite message UUID、`pubDate` は元の `publishedAt` です。編集後も GUID と公開日時は変わらず、
-本文だけが現在の revision に更新されます。
+RSS GUID は安定した suite message UUID、`pubDate` はその安定メンバーの元の `publishedAt` です。アルバムでは caption
+編集に左右されないメンバー UUID を RSS GUID のアンカーにします。一方、アルバムカードと RSS item のリンクは本文を
+提供するメンバーを指すため、開いた詳細と表示中の caption が一致します。編集後も GUID と公開日時は変わらず、本文だけが
+現在の revision に更新されます。
 
 ## キャッシュと障害境界
 

--- a/docs/features/moments.md
+++ b/docs/features/moments.md
@@ -81,11 +81,15 @@ canonical 动态区域，不会复制为 `/en` 或 `/ja` 路由。正文和媒�
 Telegram 仍是来源，但页面文案统一使用“查看源消息”。无法构造公开来源 URL 时不会生成假链接。
 
 消息保持 newest-first。feed 中长正文会在有 JavaScript 且确认溢出后折叠，详情页始终展示完整
-正文。`revision > 1` 只表示“已更新”，不会伪造编辑时间。每条 suite message 都保持独立，第一版
-不会根据 Telegram `mediaGroupId` 猜测跨消息相册。
+正文。`revision > 1` 只表示“已更新”，不会伪造编辑时间。feed 会把相邻且具有同一
+`mediaGroupId` 的消息显示为一个相册；Telegram Desktop JSON 缺少该字段时，仅在同频道、同一
+时间、来源消息 ID 连续、每条都有媒体且最多一条含正文时进行保守合并。跨 cursor 边界的候选组
+保持独立，避免隐藏未加载的媒体；聚合卡片展示相册全部媒体且每项保留自己的来源链接，每条 suite
+message 的 UUID 和详情永久链接仍然有效。
 
-RSS 的 GUID 使用稳定的 suite message UUID，`pubDate` 使用原始 `publishedAt`；编辑后 GUID 和
-pubDate 不变，正文更新为当前 revision。
+RSS 的 GUID 使用稳定的 suite message UUID，`pubDate` 使用该稳定成员的原始 `publishedAt`；相册使用
+不随 caption 编辑变化的成员 UUID 作为 RSS GUID 锚点。聚合卡片和 RSS item 的链接则跟随实际提供正文的
+成员，确保打开的详情与所见正文一致；编辑后 GUID 和 pubDate 不变，正文更新为当前 revision。
 
 ## 缓存与故障边界
 

--- a/src/components/moments/MediaGallery.astro
+++ b/src/components/moments/MediaGallery.astro
@@ -17,12 +17,12 @@ interface Labels {
 interface Props {
   media: MomentMediaViewModel[];
   detail?: boolean;
-  sourceUrl?: string | null;
+  showAll?: boolean;
   labels: Labels;
 }
 
-const { media, detail = false, sourceUrl, labels } = Astro.props;
-const visible = detail ? media : media.slice(0, 4);
+const { media, detail = false, showAll = false, labels } = Astro.props;
+const visible = detail || showAll ? media : media.slice(0, 4);
 const remaining = Math.max(0, media.length - visible.length);
 const columns = visible.length === 1 ? 'grid-cols-1' : 'grid-cols-2';
 ---
@@ -32,7 +32,7 @@ const columns = visible.length === 1 ? 'grid-cols-1' : 'grid-cols-2';
     <moments-media-gallery class={`relative grid ${columns} gap-2`}>
       {visible.map((attachment, index) => (
         <div class:list={['relative min-w-0', visible.length === 3 && index === 0 ? 'col-span-2' : '']}>
-          <MediaAttachment media={attachment} sourceUrl={sourceUrl} labels={labels} />
+          <MediaAttachment media={attachment} sourceUrl={attachment.sourceUrl} labels={labels} />
           {remaining > 0 && index === visible.length - 1 && (
             <span
               class="pointer-events-none absolute inset-0 flex items-center justify-center rounded-lg bg-black/60 text-2xl font-bold text-white"

--- a/src/components/moments/MessageCard.astro
+++ b/src/components/moments/MessageCard.astro
@@ -80,20 +80,22 @@ const railDate = publishedDate?.slice(0, 4) === currentYear ? publishedDate.slic
     </div>
   </header>
 
-  <MessageBody
-    html={message.html}
-    collapsible={!detail}
-    emptyLabel={labels.emptyMessage}
-    expandLabel={labels.expand}
-    collapseLabel={labels.collapse}
-  />
+  {(message.html || message.media.length === 0) && (
+    <MessageBody
+      html={message.html}
+      collapsible={!detail}
+      emptyLabel={labels.emptyMessage}
+      expandLabel={labels.expand}
+      collapseLabel={labels.collapse}
+    />
+  )}
 
   {message.media.length > 0 && (
     <div class="mt-2.5">
       <MediaGallery
         media={message.media}
         detail={detail}
-        sourceUrl={message.sourceUrl}
+        showAll={message.showAllMedia}
         labels={{
           processing: labels.mediaProcessing,
           unavailable: labels.mediaUnavailable,

--- a/src/components/moments/types.ts
+++ b/src/components/moments/types.ts
@@ -21,6 +21,7 @@ export interface MomentMediaViewModel {
   fileSize?: number | null;
   mimeType?: string | null;
   alt?: string | null;
+  sourceUrl?: string | null;
 }
 
 export interface MomentMessageViewModel {
@@ -34,6 +35,7 @@ export interface MomentMessageViewModel {
   permalink: string;
   sourceUrl?: string | null;
   media: MomentMediaViewModel[];
+  showAllMedia?: boolean;
   tags: MomentTagViewModel[];
 }
 

--- a/src/features/moments/lib/message-groups.ts
+++ b/src/features/moments/lib/message-groups.ts
@@ -1,0 +1,132 @@
+import type { PublicMessage } from '@coszone/koharu-astro';
+
+const TELEGRAM_ALBUM_LIMIT = 10;
+
+export interface MomentMessageGroup {
+  anchor: PublicMessage;
+  messages: readonly PublicMessage[];
+  primary: PublicMessage;
+}
+
+export interface GroupMomentMessagesOptions {
+  /** The first API item may continue an album from the previous cursor page. */
+  separateFirst?: boolean;
+  /** The last API item may continue an album on the next cursor page. */
+  separateLast?: boolean;
+}
+
+interface TelegramSourceMessage {
+  channel: string;
+  id: bigint;
+}
+
+function hasVisibleBody(message: PublicMessage): boolean {
+  return Boolean(message.content.text?.trim() || message.content.html?.trim());
+}
+
+function telegramSourceMessage(message: PublicMessage): TelegramSourceMessage | undefined {
+  if (!message.sourceUrl) return undefined;
+
+  let url: URL;
+  try {
+    url = new URL(message.sourceUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (url.protocol !== 'https:' || !['t.me', 'www.t.me'].includes(url.hostname.toLowerCase())) return undefined;
+  const match = url.pathname.match(/^\/([^/]+)\/(\d+)\/?$/u);
+  if (!match) return undefined;
+
+  return {
+    channel: match[1].toLowerCase(),
+    id: BigInt(match[2]),
+  };
+}
+
+function hasSameExplicitMediaGroup(messages: readonly PublicMessage[], candidate: PublicMessage): boolean {
+  const mediaGroupId = messages[0]?.mediaGroupId;
+  return Boolean(
+    mediaGroupId &&
+      candidate.mediaGroupId === mediaGroupId &&
+      messages.every((message) => message.channel.id === candidate.channel.id),
+  );
+}
+
+function stableGroupAnchor(messages: readonly PublicMessage[]): PublicMessage | undefined {
+  const first = messages[0];
+  if (!first) return undefined;
+  const sources = messages.map(telegramSourceMessage);
+  const firstSource = sources[0];
+  if (firstSource && sources.every((source) => source?.channel === firstSource.channel)) {
+    return messages.slice(1).reduce((anchor, candidate, index) => {
+      const anchorSource = telegramSourceMessage(anchor);
+      const candidateSource = sources[index + 1];
+      return anchorSource && candidateSource && candidateSource.id < anchorSource.id ? candidate : anchor;
+    }, first);
+  }
+
+  return messages
+    .slice(1)
+    .reduce((anchor, candidate) => (candidate.id.localeCompare(anchor.id) < 0 ? candidate : anchor), first);
+}
+
+function looksLikeDesktopAlbum(messages: readonly PublicMessage[], candidate: PublicMessage): boolean {
+  const first = messages[0];
+  const previous = messages.at(-1);
+  if (!first || !previous || messages.length >= TELEGRAM_ALBUM_LIMIT) return false;
+  if (candidate.mediaGroupId !== null || messages.some((message) => message.mediaGroupId !== null)) return false;
+  if (candidate.channel.id !== first.channel.id || candidate.publishedAt !== first.publishedAt) return false;
+  if (candidate.media.length === 0 || messages.some((message) => message.media.length === 0)) return false;
+
+  const bodyCount = messages.filter(hasVisibleBody).length + Number(hasVisibleBody(candidate));
+  if (bodyCount > 1) return false;
+
+  const previousSource = telegramSourceMessage(previous);
+  const candidateSource = telegramSourceMessage(candidate);
+  if (!previousSource || !candidateSource || previousSource.channel !== candidateSource.channel) return false;
+
+  const difference = candidateSource.id - previousSource.id;
+  return difference === 1n || difference === -1n;
+}
+
+function toGroup(messages: readonly PublicMessage[]): MomentMessageGroup {
+  const anchor = stableGroupAnchor(messages);
+  if (!anchor) throw new TypeError('Moment message groups cannot be empty.');
+  const primary = messages.find(hasVisibleBody) ?? anchor;
+  return {
+    anchor,
+    messages,
+    primary,
+  };
+}
+
+function separateBoundaryGroups(groups: readonly PublicMessage[][], options: GroupMomentMessagesOptions): PublicMessage[][] {
+  return groups.flatMap((messages, index) => {
+    const isProtectedBoundary = (index === 0 && options.separateFirst) || (index === groups.length - 1 && options.separateLast);
+    return isProtectedBoundary && messages.length > 1 ? messages.map((message) => [message]) : [messages];
+  });
+}
+
+/**
+ * Groups contiguous Telegram album members without changing their stable Suite identities.
+ * Desktop JSON omits media_group_id, so the fallback deliberately requires every signal that
+ * survives export: one timestamp, consecutive source IDs, media on every member, and at most one caption.
+ */
+export function groupMomentMessages(
+  messages: readonly PublicMessage[],
+  options: GroupMomentMessagesOptions = {},
+): MomentMessageGroup[] {
+  const groups: PublicMessage[][] = [];
+
+  for (const message of messages) {
+    const current = groups.at(-1);
+    if (current && (hasSameExplicitMediaGroup(current, message) || looksLikeDesktopAlbum(current, message))) {
+      current.push(message);
+    } else {
+      groups.push([message]);
+    }
+  }
+
+  return separateBoundaryGroups(groups, options).map(toGroup);
+}

--- a/src/features/moments/lib/rss.ts
+++ b/src/features/moments/lib/rss.ts
@@ -1,12 +1,14 @@
 import rss from '@astrojs/rss';
 import type { PublicMessage } from '@coszone/koharu-astro';
 import type { NormalizedMomentsConfig, ResolvedMomentsChannel } from '@lib/config/moments';
+import { groupMomentMessages } from './message-groups';
 import { messagePath } from './urls';
 
 export async function buildMomentsRss(options: {
   channels: readonly ResolvedMomentsChannel[];
   config: NormalizedMomentsConfig;
   description: string;
+  hasMore?: boolean;
   messages: readonly PublicMessage[];
   site: URL;
   title: string;
@@ -17,19 +19,19 @@ export async function buildMomentsRss(options: {
     description: options.description,
     site: options.site,
     trailingSlash: false,
-    items: options.messages.flatMap((message) => {
-      const channel = channelsById.get(message.channel.id);
+    items: groupMomentMessages(options.messages, { separateLast: options.hasMore }).flatMap(({ anchor, primary }) => {
+      const channel = channelsById.get(primary.channel.id);
       if (!channel) return [];
-      const plain = message.content.text?.replace(/\s+/g, ' ').trim();
+      const plain = primary.content.text?.replace(/\s+/g, ' ').trim();
       const title = plain ? (plain.length > 80 ? `${plain.slice(0, 79)}…` : plain) : `${channel.title} · 媒体消息`;
       return [
         {
           title,
-          pubDate: new Date(message.publishedAt),
+          pubDate: new Date(anchor.publishedAt),
           description: plain ?? options.description,
-          link: messagePath(options.config, channel, message.id),
-          content: message.content.html ?? (plain ? `<p>${escapeXml(plain)}</p>` : undefined),
-          customData: `<guid isPermaLink="false">urn:uuid:${message.id}</guid>`,
+          link: messagePath(options.config, channel, primary.id),
+          content: primary.content.html ?? (plain ? `<p>${escapeXml(plain)}</p>` : undefined),
+          customData: `<guid isPermaLink="false">urn:uuid:${anchor.id}</guid>`,
         },
       ];
     }),

--- a/src/features/moments/lib/view-models.ts
+++ b/src/features/moments/lib/view-models.ts
@@ -9,6 +9,7 @@ import type {
 import type { MessageContextReference, PublicMedia, PublicMessage } from '@coszone/koharu-astro';
 import type { NormalizedMomentsConfig, ResolvedMomentsChannel } from '@lib/config/moments';
 import { displayDate } from '@lib/date';
+import { type GroupMomentMessagesOptions, groupMomentMessages } from './message-groups';
 import { getKoharuClient } from './runtime';
 import { channelPath, messagePath, searchPath } from './urls';
 
@@ -47,7 +48,7 @@ function toTags(config: NormalizedMomentsConfig, plainText?: string): MomentTagV
   return tags;
 }
 
-function toMedia(media: PublicMedia): MomentMediaViewModel {
+function toMedia(media: PublicMedia, sourceUrl: string | null): MomentMediaViewModel {
   const client = getKoharuClient();
   return {
     id: media.id,
@@ -59,6 +60,7 @@ function toMedia(media: PublicMedia): MomentMediaViewModel {
     fileSize: parseFileSize(media.fileSize),
     mimeType: media.mimeType,
     alt: media.fileName,
+    sourceUrl,
   };
 }
 
@@ -95,9 +97,28 @@ export function toMessageViewModel(
     plainText,
     permalink,
     sourceUrl: message.sourceUrl,
-    media: message.media.map(toMedia),
+    media: message.media.map((media) => toMedia(media, message.sourceUrl)),
     tags: toTags(config, plainText),
   };
+}
+
+export function toMessageViewModels(
+  config: NormalizedMomentsConfig,
+  channel: ResolvedMomentsChannel,
+  messages: readonly PublicMessage[],
+  options: GroupMomentMessagesOptions = {},
+): MomentMessageViewModel[] {
+  return groupMomentMessages(messages, options).map((group) => {
+    const primary = toMessageViewModel(config, channel, group.primary);
+    if (group.messages.length === 1) return primary;
+
+    return {
+      ...primary,
+      media: group.messages.flatMap((message) => message.media.map((media) => toMedia(media, message.sourceUrl))),
+      revision: Math.max(...group.messages.map((message) => message.revision)),
+      showAllMedia: true,
+    };
+  });
 }
 
 export function toContextViewModel(

--- a/src/features/moments/pages/channel-rss.ts
+++ b/src/features/moments/pages/channel-rss.ts
@@ -18,6 +18,7 @@ export const GET: APIRoute = async (context) => {
       channels: [channel],
       config: momentsConfig,
       description: momentsConfig.description,
+      hasMore: Boolean(page.nextCursor),
       messages: page.items.slice(0, 50),
       site: context.site,
       title: `${channel.title} · ${momentsConfig.title}`,

--- a/src/features/moments/pages/channel.astro
+++ b/src/features/moments/pages/channel.astro
@@ -12,7 +12,7 @@ import { messageCardLabels, momentsLabels } from '../lib/labels';
 import { resolveMomentsOpenGraph } from '../lib/metadata';
 import { toMomentsHttpError } from '../lib/runtime';
 import { channelPath, rssPath } from '../lib/urls';
-import { toChannelViewModel, toMessageViewModel } from '../lib/view-models';
+import { toChannelViewModel, toMessageViewModels } from '../lib/view-models';
 
 Astro.cache.set({ maxAge: 300, swr: 30 });
 const cursor = Astro.url.searchParams.get('cursor')?.trim() || undefined;
@@ -44,7 +44,13 @@ const canonicalPath = channel ? channelPath(momentsConfig, channel) : Astro.url.
 const canonical = new URL(canonicalPath, Astro.site).href;
 const openGraph = resolveMomentsOpenGraph({ canonical, channel, config: momentsConfig, kind: 'channel' });
 const channelViews = (channels?.visible ?? []).map((item) => toChannelViewModel(momentsConfig, item, channel?.id));
-const messages = channel && page ? page.items.map((message) => toMessageViewModel(momentsConfig, channel, message)) : [];
+const messages =
+  channel && page
+    ? toMessageViewModels(momentsConfig, channel, page.items, {
+        separateFirst: Boolean(cursor),
+        separateLast: Boolean(page.nextCursor),
+      })
+    : [];
 const nextHref = page?.nextCursor ? `${canonicalPath}?cursor=${encodeURIComponent(page.nextCursor)}` : undefined;
 ---
 

--- a/src/features/moments/pages/global-rss.ts
+++ b/src/features/moments/pages/global-rss.ts
@@ -16,6 +16,7 @@ export const GET: APIRoute = async (context) => {
       channels: channels.visible,
       config: momentsConfig,
       description: momentsConfig.description,
+      hasMore: Boolean(page.nextCursor),
       messages: page.items,
       site: context.site,
       title: momentsConfig.title,

--- a/src/features/moments/pages/index.astro
+++ b/src/features/moments/pages/index.astro
@@ -13,7 +13,7 @@ import { messageCardLabels, momentsLabels } from '../lib/labels';
 import { resolveMomentsOpenGraph } from '../lib/metadata';
 import { toMomentsHttpError } from '../lib/runtime';
 import { momentsPath, rssPath, searchPath } from '../lib/urls';
-import { toChannelViewModel, toMessageViewModel } from '../lib/view-models';
+import { toChannelViewModel, toMessageViewModels } from '../lib/view-models';
 
 Astro.cache.set({ maxAge: 300, swr: 30 });
 const cursor = Astro.url.searchParams.get('cursor')?.trim() || undefined;
@@ -39,7 +39,13 @@ if (primary) {
 }
 
 const channelViews = (channels?.visible ?? []).map((channel) => toChannelViewModel(momentsConfig, channel, primary?.id));
-const messages = primary && page ? page.items.map((message) => toMessageViewModel(momentsConfig, primary, message)) : [];
+const messages =
+  primary && page
+    ? toMessageViewModels(momentsConfig, primary, page.items, {
+        separateFirst: Boolean(cursor),
+        separateLast: Boolean(page.nextCursor),
+      })
+    : [];
 const canonicalPath = momentsPath(momentsConfig);
 const canonical = new URL(canonicalPath, Astro.site).href;
 const openGraph = resolveMomentsOpenGraph({ canonical, config: momentsConfig, kind: 'index' });

--- a/tests/moments/fixture-server.mjs
+++ b/tests/moments/fixture-server.mjs
@@ -62,6 +62,53 @@ const message = {
   revision: 2,
   sourceUrl: 'https://t.me/daily/1',
 };
+const albumMessages = [
+  message,
+  {
+    ...message,
+    id: '018f3f7a-2b1c-7def-8abc-1234567890b2',
+    content: { kind: 'none', text: null, html: null, entities: [] },
+    media: [
+      {
+        ...message.media[2],
+        id: '018f3f7a-2b1c-7def-8abc-1234567890b4',
+        fileName: 'second-unavailable.jpg',
+        mimeType: 'image/jpeg',
+        kind: 'photo',
+      },
+    ],
+    authorSignature: null,
+    revision: 1,
+    sourceUrl: 'https://t.me/daily/2',
+  },
+  {
+    ...message,
+    id: '018f3f7a-2b1c-7def-8abc-1234567890b3',
+    content: { kind: 'none', text: null, html: null, entities: [] },
+    media: [
+      {
+        ...message.media[2],
+        id: '018f3f7a-2b1c-7def-8abc-1234567890b5',
+        fileName: 'third-unavailable.jpg',
+        mimeType: 'image/jpeg',
+        kind: 'photo',
+      },
+    ],
+    authorSignature: null,
+    revision: 1,
+    sourceUrl: 'https://t.me/daily/3',
+  },
+];
+const unrelatedMessage = {
+  ...message,
+  id: '018f3f7a-2b1c-7def-8abc-1234567890b6',
+  content: { kind: 'text', text: 'Older fixture message', html: '<p>Older fixture message</p>', entities: [] },
+  media: [],
+  mediaGroupId: null,
+  publishedAt: '2026-07-25T11:59:00.000Z',
+  revision: 1,
+  sourceUrl: 'https://t.me/daily/0',
+};
 const mismatchMessageId = '018f3f7a-2b1c-7def-8abc-1234567890b0';
 
 function send(response, status, body, headers = {}) {
@@ -78,8 +125,10 @@ const server = http.createServer((request, response) => {
   }
   if (url.searchParams.get('cursor') === 'invalid') return send(response, 200, { unexpected: true });
 
-  if (url.pathname === '/api/v1/messages') return send(response, 200, { items: [message], nextCursor: 'older-page' });
-  if (url.pathname === '/api/v1/messages/latest') return send(response, 200, { items: [message], nextCursor: null });
+  if (url.pathname === '/api/v1/messages') {
+    return send(response, 200, { items: [...albumMessages, unrelatedMessage], nextCursor: 'older-page' });
+  }
+  if (url.pathname === '/api/v1/messages/latest') return send(response, 200, { items: albumMessages, nextCursor: null });
   if (url.pathname === '/api/v1/search/messages') {
     return send(response, 200, {
       items: [{ match: { score: 1, snippet: 'Fixture hello' }, message }],

--- a/tests/moments/message-groups.test.ts
+++ b/tests/moments/message-groups.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { PublicMedia, PublicMessage } from '@coszone/koharu-astro';
+import { groupMomentMessages } from '../../src/features/moments/lib/message-groups';
+import type { ResolvedMomentsChannel } from '../../src/lib/config/moments';
+
+const channel: ResolvedMomentsChannel = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  slug: 'daily',
+  title: 'Daily',
+  username: 'daily_channel',
+  primary: true,
+  hidden: false,
+  aliases: [],
+};
+
+function media(id: number): PublicMedia {
+  return {
+    id: `018f3f7a-2b1c-7def-8abc-${String(id).padStart(12, '0')}`,
+    kind: 'photo',
+    cacheStatus: 'unavailable',
+    duration: null,
+    fileName: `photo-${id}.jpg`,
+    fileSize: '1024',
+    height: 640,
+    mimeType: 'image/jpeg',
+    originalUrl: null,
+    thumbnailUrl: null,
+    width: 960,
+  };
+}
+
+function message(
+  sourceId: number,
+  options: {
+    mediaGroupId?: string | null;
+    publishedAt?: string;
+    text?: string;
+    withMedia?: boolean;
+  } = {},
+): PublicMessage {
+  const text = options.text ?? '';
+  return {
+    id: `018f3f7a-2b1c-7def-8abc-${String(sourceId).padStart(12, '0')}`,
+    channel: { id: channel.id, title: channel.title, username: channel.username ?? null },
+    content: { kind: text ? 'caption' : 'none', text: text || null, html: text ? `<p>${text}</p>` : null, entities: [] },
+    media: options.withMedia === false ? [] : [media(sourceId)],
+    mediaGroupId: options.mediaGroupId ?? null,
+    authorSignature: null,
+    publishedAt: options.publishedAt ?? '2026-07-31T06:23:35.000Z',
+    revision: 1,
+    sourceUrl: `https://t.me/daily_channel/${sourceId}`,
+  };
+}
+
+test('merges a Telegram Desktop album using conservative export signals', () => {
+  const messages = [message(3902, { text: '#碎碎念 正文' }), message(3903), message(3904)];
+  const groups = groupMomentMessages(messages);
+
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].anchor.id, messages[0].id);
+  assert.equal(groups[0].primary.id, messages[0].id);
+  assert.deepEqual(
+    groups[0].messages.map((item) => item.sourceUrl),
+    messages.map((item) => item.sourceUrl),
+  );
+  assert.deepEqual(
+    groups[0].messages.flatMap((item) => item.media.map((attachment) => attachment.id)),
+    messages.map((item) => item.media[0].id),
+  );
+});
+
+test('uses an explicit mediaGroupId without relying on source URL inference', () => {
+  const messages = [
+    { ...message(10, { mediaGroupId: 'album-1', text: 'caption' }), sourceUrl: null },
+    {
+      ...message(99, { mediaGroupId: 'album-1', publishedAt: '2026-07-31T06:23:36.000Z' }),
+      sourceUrl: null,
+    },
+  ];
+
+  assert.equal(groupMomentMessages(messages).length, 1);
+});
+
+test('keeps the stable album anchor when a caption is added to another member', () => {
+  const before = [message(10), message(11)];
+  const after = [message(10), message(11, { text: 'Added later' })];
+
+  assert.equal(groupMomentMessages(before)[0].anchor.id, before[0].id);
+  assert.equal(groupMomentMessages(after)[0].anchor.id, before[0].id);
+  assert.equal(groupMomentMessages(after)[0].primary.id, after[1].id);
+});
+
+test('does not infer an album from a timestamp alone', () => {
+  const nonConsecutive = [message(3902, { text: 'caption' }), message(3904)];
+  const multipleCaptions = [message(3902, { text: 'first' }), message(3903, { text: 'second' })];
+  const missingMedia = [message(3902, { text: 'caption' }), message(3903, { withMedia: false })];
+
+  assert.equal(groupMomentMessages(nonConsecutive).length, 2);
+  assert.equal(groupMomentMessages(multipleCaptions).length, 2);
+  assert.equal(groupMomentMessages(missingMedia).length, 2);
+});
+
+test('never infers more members than one Telegram album can contain', () => {
+  const messages = Array.from({ length: 11 }, (_, index) => message(100 + index));
+  const groups = groupMomentMessages(messages);
+
+  assert.deepEqual(
+    groups.map((group) => group.messages.length),
+    [10, 1],
+  );
+});
+
+test('keeps an album separate when it touches an unknown cursor boundary', () => {
+  const messages = [message(3902, { text: 'caption' }), message(3903), message(3904)];
+
+  assert.equal(groupMomentMessages(messages, { separateFirst: true }).length, 3);
+  assert.equal(groupMomentMessages(messages, { separateLast: true }).length, 3);
+});

--- a/tests/moments/rss.test.ts
+++ b/tests/moments/rss.test.ts
@@ -42,3 +42,114 @@ test('uses the suite UUID as a stable non-permalink GUID and links back to the b
   assert.match(xml, /Sat, 25 Jul 2026 12:00:00 GMT/);
   assert.match(xml, /Edited body/);
 });
+
+test('emits one RSS item for a contiguous media album', async () => {
+  const album = [
+    {
+      ...message,
+      media: [
+        {
+          id: '018f3f7a-2b1c-7def-8abc-1234567890ac',
+          kind: 'photo' as const,
+          cacheStatus: 'unavailable' as const,
+          duration: null,
+          fileName: 'first.jpg',
+          fileSize: '1024',
+          height: 640,
+          mimeType: 'image/jpeg',
+          originalUrl: null,
+          thumbnailUrl: null,
+          width: 960,
+        },
+      ],
+      sourceUrl: 'https://t.me/daily_channel/10',
+    },
+    {
+      ...message,
+      id: '018f3f7a-2b1c-7def-8abc-1234567890ad',
+      content: { kind: 'none' as const, text: null, html: null, entities: [] },
+      media: [
+        {
+          id: '018f3f7a-2b1c-7def-8abc-1234567890ae',
+          kind: 'photo' as const,
+          cacheStatus: 'unavailable' as const,
+          duration: null,
+          fileName: 'second.jpg',
+          fileSize: '2048',
+          height: 640,
+          mimeType: 'image/jpeg',
+          originalUrl: null,
+          thumbnailUrl: null,
+          width: 960,
+        },
+      ],
+      sourceUrl: 'https://t.me/daily_channel/11',
+    },
+  ] satisfies PublicMessage[];
+
+  const response = await buildMomentsRss({
+    channels: [channel],
+    config: normalizeMomentsConfig({ enabled: true }),
+    description: 'Moments',
+    messages: album,
+    site: new URL('https://blog.example.com'),
+    title: 'Moments',
+  });
+  const xml = await response.text();
+
+  assert.equal(xml.match(/<item>/g)?.length, 1);
+  assert.match(xml, new RegExp(`urn:uuid:${message.id}`));
+});
+
+test('keeps the album GUID stable when a caption is added to another member', async () => {
+  const first = {
+    ...message,
+    content: { kind: 'none' as const, text: null, html: null, entities: [] },
+    media: [
+      {
+        id: '018f3f7a-2b1c-7def-8abc-1234567890ac',
+        kind: 'photo' as const,
+        cacheStatus: 'unavailable' as const,
+        duration: null,
+        fileName: 'first.jpg',
+        fileSize: '1024',
+        height: 640,
+        mimeType: 'image/jpeg',
+        originalUrl: null,
+        thumbnailUrl: null,
+        width: 960,
+      },
+    ],
+    mediaGroupId: 'album-1',
+    sourceUrl: 'https://t.me/daily_channel/10',
+  } satisfies PublicMessage;
+  const second = {
+    ...first,
+    id: '018f3f7a-2b1c-7def-8abc-1234567890ad',
+    media: [{ ...first.media[0], id: '018f3f7a-2b1c-7def-8abc-1234567890ae', fileName: 'second.jpg' }],
+    sourceUrl: 'https://t.me/daily_channel/11',
+  } satisfies PublicMessage;
+  const editedSecond = {
+    ...second,
+    content: { kind: 'caption' as const, text: 'Added later', html: '<p>Added later</p>', entities: [] },
+    revision: 2,
+  } satisfies PublicMessage;
+  const config = normalizeMomentsConfig({ enabled: true });
+  const common = {
+    channels: [channel],
+    config,
+    description: 'Moments',
+    site: new URL('https://blog.example.com'),
+    title: 'Moments',
+  };
+
+  const before = await (await buildMomentsRss({ ...common, messages: [first, second] })).text();
+  const after = await (await buildMomentsRss({ ...common, messages: [first, editedSecond] })).text();
+
+  const expectedGuid = `<guid isPermaLink="false">urn:uuid:${first.id}</guid>`;
+  assert.match(before, new RegExp(expectedGuid));
+  assert.match(after, new RegExp(expectedGuid));
+  assert.match(before, new RegExp(`https://blog\\.example\\.com/moments/daily/${first.id}`));
+  assert.match(after, new RegExp(`https://blog\\.example\\.com/moments/daily/${editedSecond.id}`));
+  assert.match(after, /Added later/);
+});

--- a/tests/moments/smoke.sh
+++ b/tests/moments/smoke.sh
@@ -28,7 +28,12 @@ base="http://127.0.0.1:${blog_port}"
 message_id='018f3f7a-2b1c-7def-8abc-1234567890ab'
 mismatch_message_id='018f3f7a-2b1c-7def-8abc-1234567890b0'
 
-curl -fsS "$base/moments" | grep -q 'Fixture hello from'
+moments_html="$(curl -fsS "$base/moments")"
+grep -q 'Fixture hello from' <<<"$moments_html"
+[[ "$(grep -o 'class="moments-message-card' <<<"$moments_html" | wc -l | tr -d ' ')" == '2' ]]
+[[ "$(grep -o 'data-media-kind=' <<<"$moments_html" | wc -l | tr -d ' ')" == '5' ]]
+grep -q 'https://t.me/daily/2' <<<"$moments_html"
+grep -q 'https://t.me/daily/3' <<<"$moments_html"
 curl -fsS "$base/moments/daily" | grep -q '媒体处理中'
 curl -fsS "$base/moments/daily/$message_id" | grep -q '查看源消息'
 curl -fsS "$base/moments/search?q=hello" | grep -q 'Fixture hello'


### PR DESCRIPTION
## Summary

- Group contiguous Telegram media album members into one Moments card and RSS item.
- Support explicit `mediaGroupId` and conservatively infer Telegram Desktop albums using the channel, timestamp, consecutive source IDs, media presence, and caption count.
- Keep groups touching cursor boundaries separate, preserve individual Suite permalinks and source links, and avoid showing “empty message” for media-only entries.
- Use a caption-independent Suite UUID as the stable RSS GUID anchor while card and RSS links follow the member that supplies the displayed body.
- Render every grouped album attachment in the feed so members beyond the normal four-item preview remain accessible.

## Changed files

- `src/features/moments/`: album grouping, stable RSS identities, content-matching card/RSS links, per-attachment source links, cursor safeguards, and media-only rendering.
- `tests/moments/`: grouping, edit stability, link/GUID behavior, false-positive, cursor-boundary, album-limit, RSS, and dynamic fixture coverage.
- `docs/`: updated Chinese, English, Japanese, and design documentation.

## Validation

- `pnpm lint`
- `pnpm test:moments` — 43/43 passed
- `pnpm check` — 0 errors, warnings, or hints
- `pnpm build` — default static profile
- Dynamic Node build and `pnpm test:moments:smoke`
- Dynamic fixture verifies a Desktop-style album renders as one card with all five media entries, distinct source links, and one RSS GUID
- Verified imported Telegram messages 3902–3904 render as one card with three media entries and one RSS GUID
