### PR TITLE
fix: preserve locale in getting-started links

### DIFF
--- a/src/content/blog/en/tools/getting-started.md
+++ b/src/content/blog/en/tools/getting-started.md
@@ -62,7 +62,7 @@ Deploy easily with Vercel:
 
 ## Learn More
 
-- Check out the [Markdown Features Demo](/post/markdown-features) for all Markdown enhancements
-- Check out the [Usage Guide](/post/astro-koharu-guide) for detailed configuration
+- Check out the [Markdown Features Demo](/en/post/markdown-features) for all Markdown enhancements
+- Check out the [Usage Guide](/en/post/astro-koharu-guide) for detailed configuration
 
 Enjoy blogging!

--- a/src/content/blog/ja/tools/getting-started.md
+++ b/src/content/blog/ja/tools/getting-started.md
@@ -62,7 +62,7 @@ Vercel で簡単にデプロイ：
 
 ## さらに詳しく
 
-- [Markdown 機能デモ](/post/markdown-features) ですべての Markdown 拡張機能をチェック
-- [使い方ガイド](/post/astro-koharu-guide) で詳細な設定方法を確認
+- [Markdown 機能デモ](/ja/post/markdown-features) ですべての Markdown 拡張機能をチェック
+- [使い方ガイド](/ja/post/astro-koharu-guide) で詳細な設定方法を確認
 
 ブログをお楽しみください！


### PR DESCRIPTION
## Summary

- keep the English and Japanese getting-started links within the active locale
- use explicit locale-prefixed paths so navigation remains correct regardless of trailing-slash handling

## Changed files

- `src/content/blog/en/tools/getting-started.md`
- `src/content/blog/ja/tools/getting-started.md`

## Validation

- `pnpm exec lint-md src/content/blog/en/tools/getting-started.md src/content/blog/ja/tools/getting-started.md`
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- verified the generated English and Japanese HTML uses locale-prefixed links